### PR TITLE
Remove project ID from parent pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,6 @@
                     <version>3.11.0</version>
                     <configuration>
                         <organisation>manoelcampos</organisation>
-                        <projectId>586ad564cf4f52001236d935</projectId>
                     </configuration>
                     <!--
                     The plugin is just being executed when the repository is pushed to travis-ci.org


### PR DESCRIPTION
Remove the VersionEye Project ID from the parent pom.xml file. That prevents the API from merging child projects. 