### PR TITLE
Refactored the way VM Cloner Function is used when Host failures happen

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/HostFaultInjectionExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/HostFaultInjectionExample1.java
@@ -89,7 +89,7 @@ public final class HostFaultInjectionExample1 {
     private static final int VM_PES = 2; //number of cpus
 
     private static final int CLOUDLET_PES = 2;
-    private static final long CLOUDLET_LENGHT = 50_000_000;
+    private static final long CLOUDLET_LENGHT = 1000_000_000L;
     private static final long CLOUDLET_FILESIZE = 300;
     private static final long CLOUDLET_OUTPUTSIZE = 300;
 
@@ -97,10 +97,10 @@ public final class HostFaultInjectionExample1 {
      * Number of Hosts to create for each Datacenter. The number of elements in
      * this array defines the number of Datacenters to be created.
      */
-    private static final int HOSTS = 25;
-    private static final int VMS = 27;
+    private static final int HOSTS = 15;
+    private static final int VMS = 10;
 
-    private static final int CLOUDLETS = 27;
+    private static final int CLOUDLETS = 16;
 
     private final List<Vm> vmlist = new ArrayList<>();
     private CloudSim simulation;
@@ -116,18 +116,18 @@ public final class HostFaultInjectionExample1 {
     public static void main(String[] args) {
         new HostFaultInjectionExample1();
     }
-   
+
     public HostFaultInjectionExample1() {
         Log.printConcatLine("Starting ", getClass().getSimpleName(), "...");
 
         simulation = new CloudSim();
 
         Datacenter datacenter = createDatacenter(HOSTS);
-        createFaultInjectionForHosts(datacenter);
 
         broker = new DatacenterBrokerSimple(simulation);
         createAndSubmitVms();
         createAndSubmitCloudlets();
+        createFaultInjectionForHosts(datacenter);
 
         simulation.start();
         new CloudletsTableBuilder(broker.getCloudletsFinishedList()).build();
@@ -140,13 +140,14 @@ public final class HostFaultInjectionExample1 {
         Log.printFormattedLine("# Hosts MTBF: %.2f minutes", fault.meanTimeBetweenHostFaultsInMinutes());
         Log.printFormattedLine("# Availability: %.2f%%", fault.availability()*100);
 
-        
+
         Log.printConcatLine(getClass().getSimpleName(), " finished!");
     }
-    
+
     public void createAndSubmitVms() {
-        for (int i = 0; i < VMS; i++) {
+        for (int i = 1; i <= VMS; i++) {
             Vm vm = createVm();
+            vm.setId(i);
             vmlist.add(vm);
         }
         broker.submitVmList(vmlist);
@@ -241,17 +242,18 @@ public final class HostFaultInjectionExample1 {
      */
     private void createFaultInjectionForHosts(Datacenter datacenter) {
         //final long seed = System.currentTimeMillis();
-        long seed = System.currentTimeMillis();
+        long seed = 83787384734L;
         /*The average number of failures expected to happen each minute
         in a Poisson Process, which is also called event rate or rate parameter.*/
-        final double meanFailureNumberPerMinute = 0.006;
+        final double meanFailureNumberPerMinute = 0.0009;
         PoissonDistr poisson = new PoissonDistr(meanFailureNumberPerMinute, seed);
 
         fault = new HostFaultInjection(datacenter, poisson);
-        fault.setVmCloner(this::cloneVm);
+        this.vmlist.stream().forEach(vm -> fault.setVmCloner(vm, this::cloneVm));
         fault.setCloudletsCloner(this::cloneCloudlets);
+
         Log.printFormattedLine(
-                "\tFault Injection created for %s.\n\tMean Number of Failures per Minute: %.2f (1 failure expected at each %.2f minutes).",
+                "\tFault Injection created for %s.\n\tMean Number of Failures per Minute: %.6f (1 failure expected at each %.2f minutes).",
                 datacenter, meanFailureNumberPerMinute, poisson.getInterarrivalMeanTime());
     }
 
@@ -268,7 +270,7 @@ public final class HostFaultInjectionExample1 {
     private Vm cloneVm(Vm vm) {
         Vm clone = new VmSimple((long) vm.getMips(), (int) vm.getNumberOfPes());
         /*It' not required to set an ID for the clone.
-        It is being set here just to make it easy to 
+        It is being set here just to make it easy to
         relate the ID of the vm to its clone,
         since the clone ID will be 10 times the id of its
         source VM.*/
@@ -318,7 +320,7 @@ public final class HostFaultInjectionExample1 {
                         source.getLength(),
                         (int) source.getNumberOfPes());
         /*It' not required to set an ID for the clone.
-        It is being set here just to make it easy to 
+        It is being set here just to make it easy to
         relate the ID of the cloudlet to its clone,
         since the clone ID will be 10 times the id of its
         source cloudlet.*/

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/HostFaultInjectionExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/HostFaultInjectionExample1.java
@@ -249,8 +249,8 @@ public final class HostFaultInjectionExample1 {
         PoissonDistr poisson = new PoissonDistr(meanFailureNumberPerMinute, seed);
 
         fault = new HostFaultInjection(datacenter, poisson);
-        this.vmlist.stream().forEach(vm -> fault.setVmCloner(vm, this::cloneVm));
-        fault.setCloudletsCloner(this::cloneCloudlets);
+        this.vmlist.stream().forEach(vm -> fault.addVmCloner(broker, this::cloneVm));
+        fault.addCloudletsCloner(broker, this::cloneCloudlets);
 
         Log.printFormattedLine(
                 "\tFault Injection created for %s.\n\tMean Number of Failures per Minute: %.6f (1 failure expected at each %.2f minutes).",

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/HostFaultInjectionExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/HostFaultInjectionExample1.java
@@ -89,7 +89,7 @@ public final class HostFaultInjectionExample1 {
     private static final int VM_PES = 2; //number of cpus
 
     private static final int CLOUDLET_PES = 2;
-    private static final long CLOUDLET_LENGHT = 1000_000_000L;
+    private static final long CLOUDLET_LENGHT = 2800_000_000L;
     private static final long CLOUDLET_FILESIZE = 300;
     private static final long CLOUDLET_OUTPUTSIZE = 300;
 
@@ -98,9 +98,9 @@ public final class HostFaultInjectionExample1 {
      * this array defines the number of Datacenters to be created.
      */
     private static final int HOSTS = 15;
-    private static final int VMS = 10;
+    private static final int VMS = 6;
 
-    private static final int CLOUDLETS = 16;
+    private static final int CLOUDLETS = 6;
 
     private final List<Vm> vmlist = new ArrayList<>();
     private CloudSim simulation;
@@ -242,13 +242,15 @@ public final class HostFaultInjectionExample1 {
      */
     private void createFaultInjectionForHosts(Datacenter datacenter) {
         //final long seed = System.currentTimeMillis();
-        long seed = 83787384734L;
+        long seed = 87384734L;
         /*The average number of failures expected to happen each minute
         in a Poisson Process, which is also called event rate or rate parameter.*/
         final double meanFailureNumberPerMinute = 0.0009;
         PoissonDistr poisson = new PoissonDistr(meanFailureNumberPerMinute, seed);
 
         fault = new HostFaultInjection(datacenter, poisson);
+        fault.setMaxTimeToGenerateFailure(500_000L);
+
         this.vmlist.stream().forEach(vm -> fault.addVmCloner(broker, this::cloneVm));
         fault.addCloudletsCloner(broker, this::cloneCloudlets);
 

--- a/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionExperiment.java
@@ -2,10 +2,308 @@
  */
 package hostFaultInjection;
 
+import static hostFaultInjection.HostFaultInjectionRunner.CLOUDLETS;
+import static hostFaultInjection.HostFaultInjectionRunner.VMS;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.cloudbus.cloudsim.brokers.DatacenterBroker;
+import org.cloudbus.cloudsim.brokers.DatacenterBrokerSimple;
+import org.cloudbus.cloudsim.cloudlets.Cloudlet;
+import org.cloudbus.cloudsim.cloudlets.CloudletSimple;
+import org.cloudbus.cloudsim.datacenters.Datacenter;
+import org.cloudbus.cloudsim.datacenters.DatacenterSimple;
+import org.cloudbus.cloudsim.distributions.PoissonDistr;
+import org.cloudbus.cloudsim.hosts.Host;
+import org.cloudbus.cloudsim.hosts.HostSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.ResourceProvisioner;
+import org.cloudbus.cloudsim.provisioners.ResourceProvisionerSimple;
+import org.cloudbus.cloudsim.resources.Pe;
+import org.cloudbus.cloudsim.resources.PeSimple;
+import org.cloudbus.cloudsim.schedulers.cloudlet.CloudletSchedulerTimeShared;
+import org.cloudbus.cloudsim.schedulers.vm.VmScheduler;
+import org.cloudbus.cloudsim.schedulers.vm.VmSchedulerTimeShared;
+import org.cloudbus.cloudsim.util.Log;
+import org.cloudbus.cloudsim.utilizationmodels.UtilizationModel;
+import org.cloudbus.cloudsim.utilizationmodels.UtilizationModelFull;
+import org.cloudbus.cloudsim.vms.Vm;
+import org.cloudbus.cloudsim.vms.VmSimple;
+import org.cloudsimplus.builders.tables.CloudletsTableBuilder;
+import org.cloudsimplus.faultinjection.HostFaultInjection;
+import org.cloudsimplus.testbeds.SimulationExperiment;
+
 /**
  *
  * @author raysaoliveira
  */
-public class HostFaultInjectionExperiment {
-    
+public final class HostFaultInjectionExperiment extends SimulationExperiment {
+
+    private static final int SCHEDULE_TIME_TO_PROCESS_DATACENTER_EVENTS = 3;
+
+    private static final int HOST_PES = 4;
+    private static final long HOST_RAM = 500000; //host memory (MEGABYTE)
+    private static final long HOST_STORAGE = 1000000; //host storage
+    private static final long HOST_BW = 100000000L;
+    private List<Host> hostList;
+
+    private static final int VM_MIPS = 1000;
+    private static final long VM_SIZE = 1000; //image size (MEGABYTE)
+    private static final int VM_RAM = 10000; //vm memory (MEGABYTE)
+    private static final long VM_BW = 100000;
+    private static final int VM_PES = 2; //number of cpus
+
+    private static final int CLOUDLET_PES = 2;
+    private static final long CLOUDLET_LENGHT = 990_000_000L;
+    private static final long CLOUDLET_FILESIZE = 300;
+    private static final long CLOUDLET_OUTPUTSIZE = 300;
+
+    /**
+     * Number of Hosts to create for each Datacenter. The number of elements in
+     * this array defines the number of Datacenters to be created.
+     */
+    private static final int HOSTS = 10;
+    private static final int BROKERS = 2;
+
+
+    private HostFaultInjection fault;
+
+    private DatacenterBrokerSimple broker;
+
+    public HostFaultInjectionExperiment() {
+        super();
+        setNumBrokersToCreate(BROKERS);
+        setAfterScenarioBuild(exp -> createFaultInjectionForHosts(getDatacenter0()));
+    }
+
+    public double getAvailability() {
+        return fault.availability() * 100;
+    }
+
+    @Override
+    protected List<Vm> createVms() {
+        List<Vm> list = new ArrayList<>(VMS);
+        final int id = getVmList().size();
+        for (int i = 0; i < VMS; i++) {
+            Vm vm = createVm(id+i);
+            vm.setBroker(broker);
+            list.add(vm);
+        }
+        return list;
+
+    }
+
+    public Vm createVm(int id) {
+        Vm vm = new VmSimple(id, VM_MIPS, VM_PES);
+        vm
+                .setRam(VM_RAM).setBw(VM_BW).setSize(VM_SIZE)
+                .setBroker(broker)
+                .setCloudletScheduler(new CloudletSchedulerTimeShared());
+        return vm;
+    }
+
+    /**
+     * Creates the number of Cloudlets defined in {@link HostFaultInjectionRunner#CLOUDLETS} and submits
+     * them to the given broker.
+     *
+     * @param broker the broker to submit cloudlets to
+     * @return the List of created Cloudlets
+     */
+    public Cloudlet createCloudlet(int id, DatacenterBroker broker) {
+        UtilizationModel utilizationModel = new UtilizationModelFull();
+        Cloudlet c
+                = new CloudletSimple(id, CLOUDLET_LENGHT, CLOUDLET_PES)
+                        .setFileSize(CLOUDLET_FILESIZE)
+                        .setOutputSize(CLOUDLET_OUTPUTSIZE)
+                        .setBroker(broker)
+                        .setUtilizationModel(utilizationModel);
+        return c;
+    }
+
+    @Override
+    protected List<Cloudlet> createCloudlets() {
+        final List<Cloudlet> list = new ArrayList<>(CLOUDLETS);
+        final int id = getCloudletList().size();
+        for (int i = 0; i < CLOUDLETS; i++) {
+            list.add(createCloudlet(id+i, broker));
+        }
+
+        return list;
+    }
+
+    @Override
+    protected DatacenterSimple createDatacenter() {
+        DatacenterSimple dc = super.createDatacenter();
+        dc.setSchedulingInterval(SCHEDULE_TIME_TO_PROCESS_DATACENTER_EVENTS);
+        return dc;
+    }
+
+    @Override
+    protected List<Host> createHosts() {
+        hostList = new ArrayList<>(HOSTS);
+        for (int i = 0; i < HOSTS; i++) {
+            hostList.add(createHost());
+        }
+        return hostList;
+
+    }
+
+    /**
+     * Creates a Host.
+     *
+     * @return
+     */
+    public Host createHost() {
+        List<Pe> pesList = new ArrayList<>(HOST_PES);
+        for (int i = 0; i < HOST_PES; i++) {
+            pesList.add(new PeSimple(8000, new PeProvisionerSimple()));
+        }
+
+        ResourceProvisioner ramProvisioner = new ResourceProvisionerSimple();
+        ResourceProvisioner bwProvisioner = new ResourceProvisionerSimple();
+        VmScheduler vmScheduler = new VmSchedulerTimeShared();
+        return new HostSimple(HOST_RAM, HOST_BW, HOST_STORAGE, pesList)
+                .setRamProvisioner(ramProvisioner)
+                .setBwProvisioner(bwProvisioner)
+                .setVmScheduler(vmScheduler);
+    }
+
+    public List<Pe> createPeList(int numberOfPEs, long mips) {
+        List<Pe> list = new ArrayList<>(numberOfPEs);
+        for (int i = 0; i < numberOfPEs; i++) {
+            list.add(new PeSimple(mips, new PeProvisionerSimple()));
+        }
+        return list;
+    }
+
+    /**
+     * Creates the fault injection for host
+     *
+     * @param datacenter
+     */
+    private void createFaultInjectionForHosts(Datacenter datacenter) {
+        //final long seed = System.currentTimeMillis();
+        final long seed = 83787384734L;
+        /*The average number of failures expected to happen each minute
+        in a Poisson Process, which is also called event rate or rate parameter.*/
+        final double meanFailureNumberPerMinute = 0.0009;
+        PoissonDistr poisson = new PoissonDistr(meanFailureNumberPerMinute, seed);
+
+        fault = new HostFaultInjection(datacenter, poisson);
+
+        for (DatacenterBroker broker : getBrokerList()) {
+            Vm lastVmFromBroker = broker.getWaitingVm(broker.getVmsWaitingList().size() - 1);
+            fault.setVmCloner(lastVmFromBroker, this::cloneVm);
+            fault.setCloudletsCloner(this::cloneCloudlets);
+        }
+
+        Log.printFormattedLine(
+                "\tFault Injection created for %s.\n\tMean Number of Failures per Minute: %.6f (1 failure expected at each %.2f minutes).",
+                datacenter, meanFailureNumberPerMinute, poisson.getInterarrivalMeanTime());
+    }
+
+    /**
+     * Clones a VM by creating another one with the same configurations of a
+     * given VM.
+     *
+     * @param vm the VM to be cloned
+     * @return the cloned (new) VM.
+     *
+     * @see
+     * #createFaultInjectionForHosts(org.cloudbus.cloudsim.datacenters.Datacenter)
+     */
+    private Vm cloneVm(Vm vm) {
+        Vm clone = new VmSimple((long) vm.getMips(), (int) vm.getNumberOfPes());
+        /*It' not required to set an ID for the clone.
+        It is being set here just to make it easy to
+        relate the ID of the vm to its clone,
+        since the clone ID will be 10 times the id of its
+        source VM.*/
+        clone.setId(vm.getId() * 10);
+        clone.setDescription("Clone of VM " + vm.getId());
+        clone
+                .setSize(vm.getStorage().getCapacity())
+                .setBw(vm.getBw().getCapacity())
+                .setRam(vm.getBw().getCapacity())
+                .setCloudletScheduler(new CloudletSchedulerTimeShared());
+        Log.printFormattedLine("\n\n#Cloning VM %d from Host %d\n\tMips %.2f Number of Pes: %d ",
+                vm.getId(), vm.getHost().getId(), clone.getMips(), clone.getNumberOfPes());
+
+        return clone;
+    }
+
+    /**
+     * Clones each Cloudlet associated to a given VM. The method is called when
+     * a VM is destroyed due to a Host failure and a snapshot from that VM (a
+     * clone) is started into another Host. In this case, all the Cloudlets
+     * which were running inside the destroyed VM will be recreated from scratch
+     * into the VM clone, re-starting their execution from the beginning.
+     *
+     * @param sourceVm the VM to clone its Cloudlets
+     * @return the List of cloned Cloudlets.
+     * @see
+     * #createFaultInjectionForHosts(org.cloudbus.cloudsim.datacenters.Datacenter)
+     */
+    private List<Cloudlet> cloneCloudlets(Vm sourceVm) {
+        final List<Cloudlet> sourceVmCloudlets = sourceVm.getCloudletScheduler().getCloudletList();
+        final List<Cloudlet> clonedCloudlets = new ArrayList<>(sourceVmCloudlets.size());
+        for (Cloudlet cl : sourceVmCloudlets) {
+            clonedCloudlets.add(cloneCloudlet(cl));
+        }
+
+        return clonedCloudlets;
+    }
+
+    /**
+     * Creates a clone from a given Cloudlet.
+     *
+     * @param source the Cloudlet to be cloned.
+     * @return the cloned (new) cloudlet
+     */
+    private Cloudlet cloneCloudlet(Cloudlet source) {
+        Cloudlet clone
+                = new CloudletSimple(
+                        source.getLength(),
+                        (int) source.getNumberOfPes());
+        /*It' not required to set an ID for the clone.
+        It is being set here just to make it easy to
+        relate the ID of the cloudlet to its clone,
+        since the clone ID will be 10 times the id of its
+        source cloudlet.*/
+        clone.setId(source.getId() * 10);
+        clone
+                .setUtilizationModelBw(source.getUtilizationModelBw())
+                .setUtilizationModelCpu(source.getUtilizationModelCpu())
+                .setUtilizationModelRam(source.getUtilizationModelRam());
+        return clone;
+    }
+
+    @Override
+    public void printResults() {
+        for(DatacenterBroker broker: getBrokerList()){
+            new CloudletsTableBuilder(broker.getCloudletsFinishedList()).build();
+        }
+    }
+
+    @Override
+    protected DatacenterBroker createBroker() {
+        return new DatacenterBrokerSimple(getCloudSim());
+    }
+
+    /**
+     * A main method just for test purposes.
+     *
+     * @param args
+     * @throws FileNotFoundException
+     * @throws IOException
+     */
+    public static void main(String[] args) throws FileNotFoundException, IOException {
+        HostFaultInjectionExperiment exp
+                = new HostFaultInjectionExperiment();
+        exp.setVerbose(true);
+        exp.run();
+        System.out.println("\t\t brozer size: " + exp.getBrokerList().size());
+
+    }
 }

--- a/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
@@ -7,9 +7,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.cloudbus.cloudsim.util.Log;
 import org.cloudsimplus.testbeds.ExperimentRunner;
 
 /**
+ ** Runs the {@link HostFaultInjectionExperiment} the number of
+ * times defines by {@link #getSimulationRuns()} and compute statistics.
  *
  * @author raysaoliveira
  */
@@ -19,8 +22,9 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
     /**
      * Different lengths that will be randomly assigned to created Cloudlets.
      */
-    static final int VMS = 25;
-    static final int CLOUDLETS = 25;
+    static final long[] CLOUDLET_LENGTHS = {2800_000_000L, 3800_000_000L, 4800_000_000L};
+    static final int VMS = 2;
+    static final int CLOUDLETS = 4;
 
     /**
      * Average of the cost total
@@ -42,7 +46,7 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
      */
     public static void main(String[] args) {
         new HostFaultInjectionRunner(true, 1475098589732L)
-                .setSimulationRuns(300)
+                .setSimulationRuns(100)
                 .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
                 .setVerbose(true)
                 .run();
@@ -79,8 +83,8 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
     @Override
     protected Map<String, List<Double>> createMetricsMap() {
         Map<String, List<Double>> map = new HashMap<>();
-        map.put("Average of Total Availability of simulation", availability);
-        map.put("Ratio VMS per HOST: ", ratioVmsPerHost);
+        map.put("Average of Total Availability of Simulation", availability);
+        map.put("VMs/Hosts Ratio: ", ratioVmsPerHost);
         return map;
     }
 
@@ -115,9 +119,9 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
         double lower = stats.getMean() - intervalSize;
         double upper = stats.getMean() + intervalSize;
         System.out.printf(
-                "\tTaskTimeCompletion mean 95%% Confidence Interval: %.2f ∓ %.2f, that is [%.2f to %.2f]\n",
+                "\tTaskTimeCompletion mean 95%% Confidence Interval: %.4f ∓ %.4f, that is [%.4f to %.4f]\n",
                 stats.getMean(), intervalSize, lower, upper);
-        System.out.printf("\tStandard Deviation: %.2f \n", stats.getStandardDeviation());
+        System.out.printf("\tStandard Deviation: %.4f \n", stats.getStandardDeviation());
     }
 
 }

--- a/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
@@ -2,10 +2,123 @@
  */
 package hostFaultInjection;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.math3.stat.descriptive.SummaryStatistics;
+import org.cloudsimplus.testbeds.ExperimentRunner;
+
 /**
  *
  * @author raysaoliveira
  */
-public class HostFaultInjectionRunner {
-    
+class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperiment>{
+
+
+    /**
+     * Different lengths that will be randomly assigned to created Cloudlets.
+     */
+    static final int VMS = 3;
+    static final int CLOUDLETS = 3;
+
+    /**
+     * Average of the cost total
+     */
+    private List<Double> availability;
+
+    /**
+     * Indicates if each experiment will output execution logs or not.
+     */
+    private final boolean experimentVerbose = false;
+
+    /**
+     * Starts the execution of the experiments the number of times defines in
+     * {@link #getSimulationRuns()}.
+     *
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        new HostFaultInjectionRunner()
+                .setSimulationRuns(300)
+                .setApplyAntitheticVariatesTechnique(true)
+                .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
+                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed 1475098589732L
+                .setVerbose(true)
+                .run();
+    }
+
+    HostFaultInjectionRunner() {
+        super();
+        availability = new ArrayList<>();
+
+    }
+
+    @Override
+    protected HostFaultInjectionExperiment createExperiment(int i) {
+        HostFaultInjectionExperiment exp
+                = new HostFaultInjectionExperiment();
+        exp.setVerbose(experimentVerbose)
+                .setAfterExperimentFinish(this::afterExperimentFinish);
+        return exp;
+    }
+
+    /**
+     * Method automatically called after every experiment finishes running. It
+     * performs some post-processing such as collection of data for statistic
+     * analysis.
+     *
+     * @param exp the finished experiment
+     */
+    private void afterExperimentFinish(HostFaultInjectionExperiment exp) {
+        availability.add(exp.getAvailability());
+    }
+
+    @Override
+    protected void setup() {/**/
+    }
+
+    @Override
+    protected Map<String, List<Double>> createMetricsMap() {
+        Map<String, List<Double>> map = new HashMap<>();
+        map.put("Average of Total Availability of simulation", availability);
+        return map;
+    }
+
+    @Override
+    protected void printSimulationParameters() {
+        System.out.printf("Executing %d experiments. Please wait ... It may take a while.\n", getSimulationRuns());
+        System.out.println("Experiments configurations:");
+        System.out.printf("\tBase seed: %d | Number of VMs: %d | Number of Cloudlets: %d\n", getBaseSeed(), VMS, CLOUDLETS);
+        System.out.printf("\tApply Antithetic Variates Technique: %b\n", isApplyAntitheticVariatesTechnique());
+        if (isApplyBatchMeansMethod()) {
+            System.out.println("\tApply Batch Means Method to reduce simulation results correlation: true");
+            System.out.printf("\tNumber of Batches for Batch Means Method: %d", getNumberOfBatches());
+            System.out.printf("\tBatch Size: %d\n", batchSizeCeil());
+        }
+        System.out.printf("\nSimulated Annealing Parameters\n");
+    }
+
+    @Override
+    protected void printFinalResults(String metricName, SummaryStatistics stats) {
+        System.out.printf("\n# %s for %d simulation runs\n", metricName, getSimulationRuns());
+        if (!simulationRunsAndNumberOfBatchesAreCompatible()) {
+            System.out.println("\tBatch means method was not be applied because the number of simulation runs is not greater than the number of batches.");
+        }
+        if (getSimulationRuns() > 1) {
+            showConfidenceInterval(stats);
+        }
+    }
+
+    private void showConfidenceInterval(SummaryStatistics stats) {
+        // Calculate 95% confidence interval
+        double intervalSize = computeConfidenceErrorMargin(stats, 0.95);
+        double lower = stats.getMean() - intervalSize;
+        double upper = stats.getMean() + intervalSize;
+        System.out.printf(
+                "\tTaskTimeCompletion mean 95%% Confidence Interval: %.2f ∓ %.2f, that is [%.2f to %.2f]\n",
+                stats.getMean(), intervalSize, lower, upper);
+        System.out.printf("\tStandard Deviation: %.2f \n", stats.getStandardDeviation());
+    }
+
 }

--- a/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
@@ -19,8 +19,8 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
     /**
      * Different lengths that will be randomly assigned to created Cloudlets.
      */
-    static final int VMS = 4;
-    static final int CLOUDLETS = 4;
+    static final int VMS = 25;
+    static final int CLOUDLETS = 25;
 
     /**
      * Average of the cost total
@@ -41,25 +41,22 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        new HostFaultInjectionRunner()
+        new HostFaultInjectionRunner(true, 1475098589732L)
                 .setSimulationRuns(300)
-                .setApplyAntitheticVariatesTechnique(true)
                 .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed 1475098589732L
                 .setVerbose(true)
                 .run();
     }
 
-    HostFaultInjectionRunner() {
-        super();
+    HostFaultInjectionRunner(final boolean applyAntitheticVariatesTechnique, final long baseSeed) {
+        super(applyAntitheticVariatesTechnique, baseSeed);
         availability = new ArrayList<>();
         ratioVmsPerHost = new ArrayList<>();
     }
 
     @Override
     protected HostFaultInjectionExperiment createExperiment(int i) {
-        HostFaultInjectionExperiment exp
-                = new HostFaultInjectionExperiment();
+        HostFaultInjectionExperiment exp = new HostFaultInjectionExperiment(i, this);
         exp.setVerbose(experimentVerbose)
                 .setAfterExperimentFinish(this::afterExperimentFinish);
         return exp;
@@ -73,14 +70,11 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
      * @param exp the finished experiment
      */
     private void afterExperimentFinish(HostFaultInjectionExperiment exp) {
-
         availability.add(exp.getAvailability());
         ratioVmsPerHost.add(exp.getRatioVmsPerHost());
     }
 
-    @Override
-    protected void setup() {/**/
-    }
+    @Override protected void setup() {/**/}
 
     @Override
     protected Map<String, List<Double>> createMetricsMap() {

--- a/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/hostFaultInjection/HostFaultInjectionRunner.java
@@ -19,13 +19,15 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
     /**
      * Different lengths that will be randomly assigned to created Cloudlets.
      */
-    static final int VMS = 3;
-    static final int CLOUDLETS = 3;
+    static final int VMS = 4;
+    static final int CLOUDLETS = 4;
 
     /**
      * Average of the cost total
      */
     private List<Double> availability;
+
+    private List<Double> ratioVmsPerHost;
 
     /**
      * Indicates if each experiment will output execution logs or not.
@@ -51,7 +53,7 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
     HostFaultInjectionRunner() {
         super();
         availability = new ArrayList<>();
-
+        ratioVmsPerHost = new ArrayList<>();
     }
 
     @Override
@@ -71,7 +73,9 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
      * @param exp the finished experiment
      */
     private void afterExperimentFinish(HostFaultInjectionExperiment exp) {
+
         availability.add(exp.getAvailability());
+        ratioVmsPerHost.add(exp.getRatioVmsPerHost());
     }
 
     @Override
@@ -82,6 +86,7 @@ class HostFaultInjectionRunner extends ExperimentRunner<HostFaultInjectionExperi
     protected Map<String, List<Double>> createMetricsMap() {
         Map<String, List<Double>> map = new HashMap<>();
         map.put("Average of Total Availability of simulation", availability);
+        map.put("Ratio VMS per HOST: ", ratioVmsPerHost);
         return map;
     }
 

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionMinimizationExperiment.java
@@ -128,8 +128,8 @@ public final class CloudletTaskTimeCompletionMinimizationExperiment extends Simu
             cpu.checkCpuUtilizationSlaContract();
             cpuUtilizationSlaContract = cpu.getMaxValueCpuUtilization();
 
-            // getCloudsim().addOnClockTickListener(this::createNewCloudlets);
-            getCloudsim().addOnClockTickListener(this::printVmsCpuUsage);
+            // getCloudSim().addOnClockTickListener(this::createNewCloudlets);
+            getCloudSim().addOnClockTickListener(this::printVmsCpuUsage);
 
         } catch (IOException ex) {
             Logger.getLogger(CloudletTaskTimeCompletionMinimizationExperiment.class.getName()).log(Level.SEVERE, null, ex);
@@ -316,7 +316,7 @@ public final class CloudletTaskTimeCompletionMinimizationExperiment extends Simu
     @Override
     protected DatacenterBroker createBroker() {
         DatacenterBroker broker0;
-        broker0 = new DatacenterBrokerSimple(getCloudsim());
+        broker0 = new DatacenterBrokerSimple(getCloudSim());
         broker0.setVmMapper(this::selectVmForCloudlet);
         broker0.setCloudletComparator(sortCloudletsByLengthReversed);
         return broker0;

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionMinimizationRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionMinimizationRunner.java
@@ -35,7 +35,7 @@ import org.cloudbus.cloudsim.distributions.ContinuousDistribution;
 
 /**
  * Runs the {@link CloudletTaskTimeCompletionMinimizationExperiment} the number of
- * times defines by {@link #numberOfSimulationRuns} and compute statistics.
+ * times defines by {@link #getSimulationRuns()} and compute statistics.
  *
  * @author raysaoliveira
  */
@@ -64,7 +64,7 @@ final class CloudletTaskTimeCompletionMinimizationRunner extends ExperimentRunne
      * Amount of cloudlet PE per PE of vm.
      */
     private List<Double> ratioOfVmPesToRequiredCloudletPesList;
-    
+
     /**
      * Average of the cost total
      */
@@ -77,22 +77,20 @@ final class CloudletTaskTimeCompletionMinimizationRunner extends ExperimentRunne
 
     /**
      * Starts the execution of the experiments the number of times defines in
-     * {@link #numberOfSimulationRuns}.
+     * {@link #getSimulationRuns()}.
      *
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        new CloudletTaskTimeCompletionMinimizationRunner()
+        new CloudletTaskTimeCompletionMinimizationRunner(true, 1475098589732L)
                 .setSimulationRuns(300)
-                .setApplyAntitheticVariatesTechnique(true)
                 .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed 1475098589732L
                 .setVerbose(true)
                 .run();
     }
 
-    CloudletTaskTimeCompletionMinimizationRunner() {
-        super();
+    CloudletTaskTimeCompletionMinimizationRunner(final boolean antitheticVariatesTechnique, final long baseSeed) {
+        super(antitheticVariatesTechnique, baseSeed);
         cloudletTaskTimeCompletion = new ArrayList<>();
         percentageOfCloudletsMeetingTaskTimeCompletion = new ArrayList<>();
         ratioOfVmPesToRequiredCloudletPesList = new ArrayList<>();
@@ -102,10 +100,10 @@ final class CloudletTaskTimeCompletionMinimizationRunner extends ExperimentRunne
 
     @Override
     protected CloudletTaskTimeCompletionMinimizationExperiment createExperiment(int i) {
-        ContinuousDistribution randCloudlet = createRandomGenAndAddSeedToList(i);
-        ContinuousDistribution randVm = createRandomGenAndAddSeedToList(i);
+        ContinuousDistribution randCloudlet = createRandomGen(i);
+        ContinuousDistribution randVm = createRandomGen(i);
         CloudletTaskTimeCompletionMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionMinimizationExperiment(randCloudlet, randVm);
+                = new CloudletTaskTimeCompletionMinimizationExperiment(i, this);
         exp.setVerbose(experimentVerbose)
                 .setAfterExperimentFinish(this::afterExperimentFinish);
         return exp;

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWithoutMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWithoutMinimizationExperiment.java
@@ -69,6 +69,8 @@ import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletion
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWithoutMinimizationRunner.CLOUDLET_LENGTHS;
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWithoutMinimizationRunner.VMS;
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWithoutMinimizationRunner.VM_PES;
+
+import org.cloudsimplus.testbeds.ExperimentRunner;
 import org.cloudsimplus.testbeds.SimulationExperiment;
 
 /**
@@ -103,10 +105,18 @@ public class CloudletTaskTimeCompletionWithoutMinimizationExperiment extends Sim
     private double cpuUtilizationSlaContract;
     private double taskTimeCompletionSlaContract;
 
-    public CloudletTaskTimeCompletionWithoutMinimizationExperiment(ContinuousDistribution randCloudlet, ContinuousDistribution randVm) {
-        super();
-        this.randCloudlet = randCloudlet;
-        this.randVm = randVm;
+    private CloudletTaskTimeCompletionWithoutMinimizationExperiment(final long seed) {
+        this(0, null, seed);
+    }
+
+    CloudletTaskTimeCompletionWithoutMinimizationExperiment(final int index, final ExperimentRunner runner) {
+        this(index, runner, -1);
+    }
+
+    private CloudletTaskTimeCompletionWithoutMinimizationExperiment(final int index, final ExperimentRunner runner, final long seed) {
+        super(index, runner, seed);
+        randCloudlet = new UniformDistr(getSeed());
+        randVm = new UniformDistr(getSeed()+1);
         try {
 
             SlaReader slaReader = new SlaReader(METRICS_FILE);
@@ -348,7 +358,6 @@ public class CloudletTaskTimeCompletionWithoutMinimizationExperiment extends Sim
      * Calculates the cost price of resources (processing, bw, memory, storage)
      * of each or all of the Datacenter VMs()
      *
-     * @param vmList
      */
     double getTotalCostPrice() {
         VmCost vmCost;
@@ -374,10 +383,8 @@ public class CloudletTaskTimeCompletionWithoutMinimizationExperiment extends Sim
      */
     public static void main(String[] args) throws FileNotFoundException, IOException {
         final long seed = System.currentTimeMillis();
-        ContinuousDistribution randCloudlet = new UniformDistr(seed);
-        ContinuousDistribution randVm = new UniformDistr(seed);
         CloudletTaskTimeCompletionWithoutMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionWithoutMinimizationExperiment(randCloudlet, randVm);
+                = new CloudletTaskTimeCompletionWithoutMinimizationExperiment(1);
         exp.setVerbose(true);
         exp.run();
         exp.getCloudletsTaskTimeCompletionAverage();

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWithoutMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWithoutMinimizationExperiment.java
@@ -118,8 +118,8 @@ public class CloudletTaskTimeCompletionWithoutMinimizationExperiment extends Sim
             cpu.checkCpuUtilizationSlaContract();
             cpuUtilizationSlaContract = cpu.getMaxValueCpuUtilization();
 
-            //  getCloudsim().addOnClockTickListener(this::createNewCloudlets);
-            getCloudsim().addOnClockTickListener(this::printVmsCpuUsage);
+            //  getCloudSim().addOnClockTickListener(this::createNewCloudlets);
+            getCloudSim().addOnClockTickListener(this::printVmsCpuUsage);
         } catch (IOException ex) {
             Logger.getLogger(CloudletTaskTimeCompletionWithoutMinimizationExperiment.class.getName()).log(Level.SEVERE, null, ex);
             throw new RuntimeException(ex);
@@ -274,7 +274,7 @@ public class CloudletTaskTimeCompletionWithoutMinimizationExperiment extends Sim
     @Override
     protected DatacenterBroker createBroker() {
         DatacenterBroker broker0;
-        broker0 = new DatacenterBrokerSimple(getCloudsim());
+        broker0 = new DatacenterBrokerSimple(getCloudSim());
         return broker0;
     }
 

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWithoutMinimizationRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWithoutMinimizationRunner.java
@@ -60,7 +60,7 @@ public class CloudletTaskTimeCompletionWithoutMinimizationRunner extends Experim
      * experiments.
      */
     private List<Double> percentageOfCloudletsMeetingTaskTimesCompletion;
-    
+
     /**
      * Amount of cloudlet PE per PE of vm.
      */
@@ -70,7 +70,7 @@ public class CloudletTaskTimeCompletionWithoutMinimizationRunner extends Experim
      * Average of the cost total
      */
     private List<Double> averageTotalCostSimulation;
-    
+
     /**
      * Indicates if each experiment will output execution logs or not.
      */
@@ -78,22 +78,20 @@ public class CloudletTaskTimeCompletionWithoutMinimizationRunner extends Experim
 
     /**
      * Starts the execution of the experiments the number of times defines in
-     * {@link #numberOfSimulationRuns}.
+     * {@link #getSimulationRuns()}.
      *
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        new CloudletTaskTimeCompletionWithoutMinimizationRunner()
+        new CloudletTaskTimeCompletionWithoutMinimizationRunner(true, 1475098589732L)
                 .setSimulationRuns(300)
-                .setApplyAntitheticVariatesTechnique(true)
                 .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed 1475098589732L
                 .setVerbose(true)
                 .run();
     }
 
-    CloudletTaskTimeCompletionWithoutMinimizationRunner() {
-        super();
+    CloudletTaskTimeCompletionWithoutMinimizationRunner(final boolean applyAntitheticVariatesTechnique, final long baseSeed) {
+        super(applyAntitheticVariatesTechnique, baseSeed);
         cloudletTaskTimesCompletion = new ArrayList<>();
         percentageOfCloudletsMeetingTaskTimesCompletion = new ArrayList<>();
         ratioOfVmPesToRequiredCloudletPesList = new ArrayList<>();
@@ -102,10 +100,10 @@ public class CloudletTaskTimeCompletionWithoutMinimizationRunner extends Experim
 
     @Override
     protected CloudletTaskTimeCompletionWithoutMinimizationExperiment createExperiment(int i) {
-        ContinuousDistribution randCloudlet = createRandomGenAndAddSeedToList(i);
-        ContinuousDistribution randVm = createRandomGenAndAddSeedToList(i);
+        ContinuousDistribution randCloudlet = createRandomGen(i);
+        ContinuousDistribution randVm = createRandomGen(i);
         CloudletTaskTimeCompletionWithoutMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionWithoutMinimizationExperiment(randCloudlet, randVm);
+                = new CloudletTaskTimeCompletionWithoutMinimizationExperiment(i, this);
         exp.setVerbose(experimentVerbose).setAfterExperimentFinish(this::afterExperimentFinish);
         return exp;
     }
@@ -136,7 +134,7 @@ public class CloudletTaskTimeCompletionWithoutMinimizationRunner extends Experim
         map.put("Percentage Of Cloudlets Meeting TaskTimesCompletion", percentageOfCloudletsMeetingTaskTimesCompletion);
         map.put("Average of vPEs/CloudletsPEs", ratioOfVmPesToRequiredCloudletPesList);
         map.put("Average of Total Cost of simulation", averageTotalCostSimulation);
-       
+
         return map;
     }
 

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadMinimizationExperiment.java
@@ -63,6 +63,8 @@ import org.cloudsimplus.sla.readJsonFile.TaskTimeCompletion;
 import org.cloudsimplus.sla.readJsonFile.SlaReader;
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWorkLoadMinimizationRunner.VMS;
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWorkLoadMinimizationRunner.VM_PES;
+
+import org.cloudsimplus.testbeds.ExperimentRunner;
 import org.cloudsimplus.testbeds.SimulationExperiment;
 
 /**
@@ -85,8 +87,6 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationExperiment extends Si
     private List<Vm> vmList;
     private List<Cloudlet> cloudletList;
 
-    private final ContinuousDistribution randCloudlet, randVm;
-
     private int createsVms;
 
     /**
@@ -102,12 +102,20 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationExperiment extends Si
      * ones.
      */
     private final Comparator<Cloudlet> sortCloudletsByLengthReversed = Comparator.comparingDouble((Cloudlet c) -> c.getLength()).reversed();
+    private ContinuousDistribution randCloudlet, randVm;
 
+    private CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(final long seed) {
+        this(0, null, seed);
+    }
 
-    public CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(ContinuousDistribution randCloudlet, ContinuousDistribution randVm) {
-        super();
-        this.randCloudlet = randCloudlet;
-        this.randVm = randVm;
+    CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(final int index, final ExperimentRunner runner) {
+        this(index, runner, -1);
+    }
+
+    private CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(final int index, final ExperimentRunner runner, final long seed) {
+        super(index, runner, seed);
+        randCloudlet = new UniformDistr(getSeed());
+        randVm = new UniformDistr(getSeed()+1);
         try {
             SlaReader slaReader = new SlaReader(METRICS_FILE);
             TaskTimeCompletion rt = new TaskTimeCompletion(slaReader);
@@ -374,10 +382,8 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationExperiment extends Si
      */
     public static void main(String[] args) throws FileNotFoundException, IOException {
         final long seed = System.currentTimeMillis();
-        ContinuousDistribution randCloudlet = new UniformDistr(seed);
-        ContinuousDistribution randVm = new UniformDistr(seed);
         CloudletTaskTimeCompletionWorkLoadMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(randCloudlet, randVm);
+            = new CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(1);
         exp.setVerbose(true);
         exp.run();
         exp.getCloudletsTaskTimeCompletionAverage();

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadMinimizationExperiment.java
@@ -278,7 +278,7 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationExperiment extends Si
     @Override
     protected DatacenterBroker createBroker() {
         DatacenterBroker broker0;
-        broker0 = new DatacenterBrokerSimple(getCloudsim());
+        broker0 = new DatacenterBrokerSimple(getCloudSim());
         broker0.setVmMapper(this::selectVmForCloudlet);
         broker0.setCloudletComparator(sortCloudletsByLengthReversed);
         return broker0;

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadMinimizationRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadMinimizationRunner.java
@@ -41,7 +41,7 @@ import org.cloudsimplus.testbeds.ExperimentRunner;
  * @author raysaoliveira
  */
 public class CloudletTaskTimeCompletionWorkLoadMinimizationRunner extends ExperimentRunner<CloudletTaskTimeCompletionWorkLoadMinimizationExperiment> {
-    
+
     /**
      * Different lengths that will be randomly assigned to created Cloudlets.
      */
@@ -59,7 +59,7 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationRunner extends Experi
      * The percentage of cloudlets meeting TaskTimeCompletion average for all the experiments.
      */
     private List<Double> percentageOfCloudletsMeetingTaskTimeCompletion;
-    
+
     /**
      * Amount of cloudlet PE per PE of vm.
      */
@@ -72,22 +72,20 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationRunner extends Experi
 
     /**
      * Starts the execution of the experiments the number of times defines in
-     * {@link #numberOfSimulationRuns}.
+     * {@link #getSimulationRuns()}.
      *
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        new CloudletTaskTimeCompletionWorkLoadMinimizationRunner()
+        new CloudletTaskTimeCompletionWorkLoadMinimizationRunner(true, 1475098589732L)
                 .setSimulationRuns(100)
-                .setApplyAntitheticVariatesTechnique(true)
                 .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed 1475098589732L
                 .setVerbose(true)
                 .run();
     }
 
-    CloudletTaskTimeCompletionWorkLoadMinimizationRunner() {
-        super();
+    CloudletTaskTimeCompletionWorkLoadMinimizationRunner(final boolean applyAntitheticVariatesTechnique, final long baseSeed) {
+        super(applyAntitheticVariatesTechnique, baseSeed);
         cloudletTaskTimesCompletion = new ArrayList<>();
         percentageOfCloudletsMeetingTaskTimeCompletion = new ArrayList<>();
         ratioOfVmPesToRequiredCloudletPesList = new ArrayList<>();
@@ -95,10 +93,10 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationRunner extends Experi
 
     @Override
     protected CloudletTaskTimeCompletionWorkLoadMinimizationExperiment createExperiment(int i) {
-        ContinuousDistribution randCloudlet = createRandomGenAndAddSeedToList(i);
-        ContinuousDistribution randVm = createRandomGenAndAddSeedToList(i);
+        ContinuousDistribution randCloudlet = createRandomGen(i);
+        ContinuousDistribution randVm = createRandomGen(i);
         CloudletTaskTimeCompletionWorkLoadMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(randCloudlet, randVm);
+                = new CloudletTaskTimeCompletionWorkLoadMinimizationExperiment(i, this);
         exp.setVerbose(experimentVerbose).setAfterExperimentFinish(this::afterExperimentFinish);
         return exp;
     }
@@ -164,5 +162,5 @@ public class CloudletTaskTimeCompletionWorkLoadMinimizationRunner extends Experi
                 stats.getMean(), intervalSize, lower, upper);
         System.out.printf("\tStandard Deviation: %.2f \n", stats.getStandardDeviation());
     }
-    
+
 }

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment.java
@@ -212,7 +212,7 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment ext
     @Override
     protected DatacenterBroker createBroker() {
         DatacenterBroker broker0;
-        broker0 = new DatacenterBrokerSimple(getCloudsim());
+        broker0 = new DatacenterBrokerSimple(getCloudSim());
         return broker0;
     }
 

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment.java
@@ -63,6 +63,8 @@ import org.cloudsimplus.sla.readJsonFile.TaskTimeCompletion;
 import org.cloudsimplus.sla.readJsonFile.SlaReader;
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner.VMS;
 import static org.cloudsimplus.sla.tasktimecompletion.CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner.VM_PES;
+
+import org.cloudsimplus.testbeds.ExperimentRunner;
 import org.cloudsimplus.testbeds.SimulationExperiment;
 
 /**
@@ -85,8 +87,6 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment ext
     private List<Vm> vmList;
     private List<Cloudlet> cloudletList;
 
-    private final ContinuousDistribution randCloudlet, randVm;
-
     private int createdCloudlets;
     private int createsVms;
 
@@ -96,11 +96,20 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment ext
     public static final String METRICS_FILE = ResourceLoader.getResourcePath(CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment.class, "SlaMetrics.json");
     private double cpuUtilizationSlaContract;
     private double taskTimeCompletionSlaContract;
+    private ContinuousDistribution randCloudlet, randVm;
 
-    public CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(ContinuousDistribution randCloudlet, ContinuousDistribution randVm) {
-        super();
-        this.randCloudlet = randCloudlet;
-        this.randVm = randVm;
+    private CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(final long seed) {
+        this(0, null, seed);
+    }
+
+    CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(final int index, final ExperimentRunner runner) {
+        this(index, runner, -1);
+    }
+
+    private CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(final int index, final ExperimentRunner runner, final long seed) {
+        super(index, runner, seed);
+        this.randCloudlet = new UniformDistr(getSeed());
+        this.randVm = new UniformDistr(getSeed()+1);
         try {
             SlaReader slaReader = new SlaReader(METRICS_FILE);
             TaskTimeCompletion rt = new TaskTimeCompletion(slaReader);
@@ -304,10 +313,8 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment ext
      */
     public static void main(String[] args) throws FileNotFoundException, IOException {
         final long seed = System.currentTimeMillis();
-        ContinuousDistribution randCloudlet = new UniformDistr(seed);
-        ContinuousDistribution randVm = new UniformDistr(seed);
         CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(randCloudlet, randVm);
+                = new CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(1);
         exp.setVerbose(true);
         exp.run();
         exp.getCloudletsTaskTimeCompletionAverage();

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/sla/tasktimecompletion/CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner.java
@@ -41,7 +41,7 @@ import org.cloudsimplus.testbeds.ExperimentRunner;
  * @author raysaoliveira
  */
 public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner extends ExperimentRunner<CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment> {
-    
+
     /**
      * Different lengths that will be randomly assigned to created Cloudlets.
      */
@@ -59,7 +59,7 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner extends
      * The percentage of cloudlets meeting TaskTimeCompletion average for all the experiments.
      */
     private List<Double> percentageOfCloudletsMeetingTaskTimeCompletion;
-    
+
     /**
      * Amount of cloudlet PE per PE of vm.
      */
@@ -72,22 +72,20 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner extends
 
     /**
      * Starts the execution of the experiments the number of times defines in
-     * {@link #numberOfSimulationRuns}.
+     * {@link #getSimulationRuns()}.
      *
      * @param args command line arguments
      */
     public static void main(String[] args) {
-        new CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner()
+        new CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner(true, 1475098589732L)
                 .setSimulationRuns(100)
-                .setApplyAntitheticVariatesTechnique(true)
                 .setNumberOfBatches(5) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed 1475098589732L
                 .setVerbose(true)
                 .run();
     }
 
-    CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner() {
-        super();
+    CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner(final boolean applyAntitheticVariatesTechnique, final long baseSeed) {
+        super(applyAntitheticVariatesTechnique, baseSeed);
         cloudletTaskTimeCompletion = new ArrayList<>();
         percentageOfCloudletsMeetingTaskTimeCompletion = new ArrayList<>();
         ratioOfVmPesToRequiredCloudletPesList = new ArrayList<>();
@@ -95,10 +93,10 @@ public class CloudletTaskTimeCompletionWorkLoadWithoutMinimizationRunner extends
 
     @Override
     protected CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment createExperiment(int i) {
-        ContinuousDistribution randCloudlet = createRandomGenAndAddSeedToList(i);
-        ContinuousDistribution randVm = createRandomGenAndAddSeedToList(i);
+        ContinuousDistribution randCloudlet = createRandomGen(i);
+        ContinuousDistribution randVm = createRandomGen(i);
         CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment exp
-                = new CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(randCloudlet, randVm);
+                = new CloudletTaskTimeCompletionWorkLoadWithoutMinimizationExperiment(i, this);
         exp.setVerbose(experimentVerbose).setAfterExperimentFinish(this::afterExperimentFinish);
         return exp;
     }

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/SimulationExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/SimulationExperiment.java
@@ -48,7 +48,7 @@ import java.util.stream.IntStream;
 public abstract class SimulationExperiment implements Runnable {
 
     private final ExperimentRunner runner;
-    public final List<Cloudlet> cloudletList;
+    private final List<Cloudlet> cloudletList;
     private final long seed;
     private List<Vm> vmList;
     private List<Host> hostList;

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/dynamiccloudlets/DynamicCloudletsArrivalExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/dynamiccloudlets/DynamicCloudletsArrivalExperiment.java
@@ -66,7 +66,7 @@ final class DynamicCloudletsArrivalExperiment extends SimulationExperiment {
 
     @Override
     protected DatacenterBroker createBroker() {
-        return new DatacenterBrokerSimple(getCloudsim());
+        return new DatacenterBrokerSimple(getCloudSim());
     }
 
     @Override

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/dynamiccloudlets/DynamicCloudletsArrivalExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/dynamiccloudlets/DynamicCloudletsArrivalExperiment.java
@@ -45,6 +45,10 @@ final class DynamicCloudletsArrivalExperiment extends SimulationExperiment {
 
     public static final int HOSTS_TO_CREATE = 100;
 
+    private DynamicCloudletsArrivalExperiment(final long seed) {
+        this(0, null, seed);
+    }
+
     /**
      * Creates a simulation experiment.
      *
@@ -54,7 +58,11 @@ final class DynamicCloudletsArrivalExperiment extends SimulationExperiment {
      * statistical analysis.
      */
     DynamicCloudletsArrivalExperiment(int index, DynamicCloudletsArrivalRunner runner) {
-        super(index, runner);
+        this(index, runner, -1);
+    }
+
+    private DynamicCloudletsArrivalExperiment(int index, DynamicCloudletsArrivalRunner runner, long seed) {
+        super(index, runner, seed);
     }
 
     @Override
@@ -93,7 +101,7 @@ final class DynamicCloudletsArrivalExperiment extends SimulationExperiment {
      * @param args
      */
     public static void main(String[] args) {
-        DynamicCloudletsArrivalExperiment exp = new DynamicCloudletsArrivalExperiment(0, null);
+        DynamicCloudletsArrivalExperiment exp = new DynamicCloudletsArrivalExperiment(1);
         exp.run();
     }
 

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/dynamiccloudlets/DynamicCloudletsArrivalRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/dynamiccloudlets/DynamicCloudletsArrivalRunner.java
@@ -36,7 +36,15 @@ import org.cloudsimplus.testbeds.ExperimentRunner;
  * @author Manoel Campos da Silva Filho
  */
 final class DynamicCloudletsArrivalRunner extends ExperimentRunner<DynamicCloudletsArrivalExperiment> {
-	@Override
+    public DynamicCloudletsArrivalRunner(boolean antitheticVariatesTechnique) {
+        super(antitheticVariatesTechnique);
+    }
+
+    public DynamicCloudletsArrivalRunner(boolean antitheticVariatesTechnique, long baseSeed){
+        super(antitheticVariatesTechnique, baseSeed);
+    }
+
+    @Override
 	protected void setup() {}
 
     @Override

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/heuristics/DatacenterBrokerHeuristicExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/heuristics/DatacenterBrokerHeuristicExperiment.java
@@ -104,11 +104,11 @@ public final class DatacenterBrokerHeuristicExperiment extends SimulationExperim
     /**
      * Instantiates the simulation experiment.
      *
+     * @param index a number the identifies the current experiment being run
      * @param runner the runner that will be in charge to setup and run the
      * experiment
-     * @param index a number the identifies the current experiment being run
      */
-    DatacenterBrokerHeuristicExperiment(DatacenterBrokerHeuristicRunner runner, int index) {
+    DatacenterBrokerHeuristicExperiment(int index, DatacenterBrokerHeuristicRunner runner) {
         super(index, runner);
         this.randomGen = new UniformDistr(0, 1);
         createSimulatedAnnealingHeuristic();

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/heuristics/DatacenterBrokerHeuristicExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/heuristics/DatacenterBrokerHeuristicExperiment.java
@@ -123,7 +123,7 @@ public final class DatacenterBrokerHeuristicExperiment extends SimulationExperim
 
     @Override
     protected DatacenterBrokerHeuristic createBroker() {
-        return new DatacenterBrokerHeuristic(getCloudsim()).setHeuristic(heuristic);
+        return new DatacenterBrokerHeuristic(getCloudSim()).setHeuristic(heuristic);
     }
 
     @Override

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/heuristics/DatacenterBrokerHeuristicRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/heuristics/DatacenterBrokerHeuristicRunner.java
@@ -42,7 +42,7 @@ import org.cloudbus.cloudsim.distributions.ContinuousDistribution;
 
 /**
  * Runs the {@link DatacenterBrokerHeuristicExperiment} the number of times
- * defines by {@link #numberOfSimulationRuns} and compute statistics.
+ * defines by {@link #getSimulationRuns()} and compute statistics.
  *
  * @author Manoel Campos da Silva Filho
  */
@@ -102,8 +102,8 @@ final class DatacenterBrokerHeuristicRunner extends ExperimentRunner<DatacenterB
      */
     private final boolean experimentVerbose = false;
 
-    DatacenterBrokerHeuristicRunner() {
-        super();
+    DatacenterBrokerHeuristicRunner(final boolean applyAntitheticVariatesTechnique, final long baseSeed) {
+        super(applyAntitheticVariatesTechnique, baseSeed);
         experimentCosts = new ArrayList<>();
         runtimeStats = new SummaryStatistics();
         vmPesArray = new int[0];
@@ -112,7 +112,7 @@ final class DatacenterBrokerHeuristicRunner extends ExperimentRunner<DatacenterB
 
     /**
      * Starts the execution of the experiments the number of times defines in
-     * {@link #numberOfSimulationRuns}.
+     * {@link #getSimulationRuns()}.
      *
      * @param args command line arguments
      */
@@ -124,11 +124,9 @@ final class DatacenterBrokerHeuristicRunner extends ExperimentRunner<DatacenterB
             NumberOfBatches: 6
             BaseSeed: 1475098589732L
          */
-        new DatacenterBrokerHeuristicRunner()
+        new DatacenterBrokerHeuristicRunner(true, 1475098589732L)
                 .setSimulationRuns(1200)
-                .setApplyAntitheticVariatesTechnique(true)
                 .setNumberOfBatches(6) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed
                 .setVerbose(true)
                 .run();
     }
@@ -194,9 +192,9 @@ final class DatacenterBrokerHeuristicRunner extends ExperimentRunner<DatacenterB
 
     @Override
     protected DatacenterBrokerHeuristicExperiment createExperiment(int i) {
-        final ContinuousDistribution prng = createRandomGenAndAddSeedToList(i, 0, 1);
+        final ContinuousDistribution prng = createRandomGen(i, 0, 1);
         final DatacenterBrokerHeuristicExperiment exp
-                = new DatacenterBrokerHeuristicExperiment(this, i)
+                = new DatacenterBrokerHeuristicExperiment(i, this)
                         .setRandomGen(prng)
                         .setCloudletPesArray(cloudletPesArray)
                         .setVmPesArray(vmPesArray);

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CloudletSchedulerExperiment.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CloudletSchedulerExperiment.java
@@ -110,7 +110,7 @@ abstract class CloudletSchedulerExperiment extends SimulationExperiment {
 
     @Override
     protected DatacenterBroker createBroker() {
-        return new DatacenterBrokerSimple(getCloudsim());
+        return new DatacenterBrokerSimple(getCloudSim());
     }
 
     @Override

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CloudletSchedulerRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CloudletSchedulerRunner.java
@@ -64,8 +64,6 @@ abstract class CloudletSchedulerRunner<T extends CloudletSchedulerExperiment> ex
      * this class.
      */
     CloudletSchedulerRunner() {
-        super();
-
         /*
 	    Values used for CloudSim Plus Paper:
 	        NumberOfSimulationRuns: 1200
@@ -73,10 +71,10 @@ abstract class CloudletSchedulerRunner<T extends CloudletSchedulerExperiment> ex
 	        NumberOfBatches: 6
 	        BaseSeed: 1475098589732L
          */
+        super(false,1475098589732L);
+
         this.setSimulationRuns(1200)
-                .setApplyAntitheticVariatesTechnique(false)
                 //.setNumberOfBatches(6) //Comment this or set to 0 to disable the "Batch Means Method"
-                .setBaseSeed(1475098589732L) //Comment this to use the current time as base seed
                 .setVerbose(true);
     }
 

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CloudletSchedulerTimeSharedRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CloudletSchedulerTimeSharedRunner.java
@@ -42,7 +42,7 @@ public class CloudletSchedulerTimeSharedRunner extends CloudletSchedulerRunner<C
 
     @Override
     protected CloudletSchedulerTimeSharedExperiment createExperiment(int i) {
-        final ContinuousDistribution cloudletPesPrng = createRandomGenAndAddSeedToList(i, 1, MAX_CLOUDLET_PES);
+        final ContinuousDistribution cloudletPesPrng = createRandomGen(i, 1, MAX_CLOUDLET_PES);
         final CloudletSchedulerTimeSharedExperiment exp = new CloudletSchedulerTimeSharedExperiment(i, this);
 
         exp

--- a/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CompletelyFairSchedulerRunner.java
+++ b/cloudsim-plus-testbeds/src/main/java/org/cloudsimplus/testbeds/linuxscheduler/CompletelyFairSchedulerRunner.java
@@ -46,7 +46,7 @@ class CompletelyFairSchedulerRunner extends CloudletSchedulerRunner<CompletelyFa
 
     @Override
     protected CompletelyFairSchedulerExperiment createExperiment(int i) {
-        final ContinuousDistribution cloudletPesPrng = createRandomGenAndAddSeedToList(i, 1, MAX_CLOUDLET_PES);
+        final ContinuousDistribution cloudletPesPrng = createRandomGen(i, 1, MAX_CLOUDLET_PES);
         final CompletelyFairSchedulerExperiment exp = new CompletelyFairSchedulerExperiment(i, this);
 
         exp

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicy.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicy.java
@@ -40,7 +40,6 @@ import org.cloudsimplus.autoscaling.VerticalVmScaling;
     /**
      * Sets the Datacenter associated to the Allocation Policy
      * @param datacenter the Datacenter to set
-     * @return
      */
     void setDatacenter(Datacenter datacenter);
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyAbstract.java
@@ -84,22 +84,13 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
     protected Map<Vm, Host> getVmHostMap() {
         return Collections.unmodifiableMap(vmHostMap);
     }
-    
+
     protected void addVmToHostMap(Vm vm, Host host){
         vmHostMap.put(vm, host);
     }
-    
+
     protected Host removeVmFromHostMap(Vm vm){
         return vmHostMap.remove(vm);
-    }
-
-    /**
-     * Sets the vm table.
-     *
-     * @param vmTable the vm table
-     */
-    protected final void setVmTable(Map<Vm, Host> vmTable) {
-        this.vmHostMap = vmTable;
     }
 
     /**
@@ -166,7 +157,7 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
      */
     private void addPesFromHostsToFreePesList() {
         setHostFreePesMap(new HashMap<>(getHostList().size()));
-        setVmTable(new HashMap<>());
+        vmHostMap = new HashMap<>();
         setUsedPes(new HashMap<>());
         getHostList().forEach(host -> hostFreePesMap.put(host, host.getNumberOfWorkingPes()));
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyAbstract.java
@@ -7,6 +7,7 @@
  */
 package org.cloudbus.cloudsim.allocationpolicies;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
     /**
      * @see #getVmHostMap()
      */
-    private Map<Vm, Host> vmTable;
+    private Map<Vm, Host> vmHostMap;
 
     /**
      * @see #getDatacenter()
@@ -73,13 +74,24 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
     }
 
     /**
-     * Gets the map between a VM and its allocated host. The map key is a VM UID
+     * Gets a <b>read-only</b> map between a VM and its allocated host. The map key is a VM
      * and the value is the allocated host for that VM.
      *
      * @return the VM map
+     * @todo after CloudSim Plus created the relationship between objects,
+     * allowing calls such as cloudlet.getVm().getHost(),
+     * this map may be unnecessary.
      */
     protected Map<Vm, Host> getVmHostMap() {
-        return vmTable;
+        return Collections.unmodifiableMap(vmHostMap);
+    }
+    
+    protected void addVmToHostMap(Vm vm, Host host){
+        vmHostMap.put(vm, host);
+    }
+    
+    protected Host removeVmFromHostMap(Vm vm){
+        return vmHostMap.remove(vm);
     }
 
     /**
@@ -88,7 +100,7 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
      * @param vmTable the vm table
      */
     protected final void setVmTable(Map<Vm, Host> vmTable) {
-        this.vmTable = vmTable;
+        this.vmHostMap = vmTable;
     }
 
     /**
@@ -103,7 +115,7 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
             return;
         }
 
-        getVmHostMap().put(vm, host);
+        addVmToHostMap(vm, host);
     }
 
     /**
@@ -120,7 +132,7 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
             return Host.NULL;
         }
 
-        Host host = getVmHostMap().remove(vm);
+        Host host = removeVmFromHostMap(vm);
         if(Objects.isNull(host)) {
             return Host.NULL;
         }
@@ -148,8 +160,8 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
     }
 
     /**
-     * Gets the number of PEs from each Host in the {@link #getHostList() host list}
-     * and adds these number of PEs to the {@link #getHostFreePesMap() list of free PEs}.
+     * Gets the number of working PEs from each Host in the {@link #getHostList() host list}
+     * and adds these numbers to the {@link #getHostFreePesMap() list of free PEs}.
      * <b>The method expects that the {@link #datacenter} is already set.</b>
      *
      */
@@ -157,7 +169,7 @@ public abstract class VmAllocationPolicyAbstract implements VmAllocationPolicy {
         setHostFreePesMap(new HashMap<>(getHostList().size()));
         setVmTable(new HashMap<>());
         setUsedPes(new HashMap<>());
-        getHostList().forEach(host -> hostFreePesMap.put(host, host.getNumberOfPes()));
+        getHostList().forEach(host -> hostFreePesMap.put(host, host.getNumberOfWorkingPes()));
     }
 
     /**

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/power/PowerVmAllocationPolicyAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/power/PowerVmAllocationPolicyAbstract.java
@@ -37,11 +37,6 @@ import org.cloudbus.cloudsim.core.Simulation;
  */
 public abstract class PowerVmAllocationPolicyAbstract extends VmAllocationPolicyAbstract implements PowerVmAllocationPolicy {
 
-    /**
-     * @see #getVmHostMap()
-     */
-    private final Map<Vm, Host> vmHostMap = new HashMap<>();
-
     @Override
     public boolean allocateHostForVm(Vm vm) {
         return allocateHostForVm(vm, findHostForVm(vm));
@@ -56,7 +51,7 @@ public abstract class PowerVmAllocationPolicyAbstract extends VmAllocationPolicy
         }
 
         if (host.vmCreate(vm)) { // if vm has been successfully created in the host
-            getVmHostMap().put(vm, host);
+            addVmToHostMap(vm, host);
             Log.printFormattedLine(
                 "%.2f: VM #" + vm.getId() + " has been allocated to the host #" + host.getId(),
                 simulation.clock());
@@ -70,27 +65,20 @@ public abstract class PowerVmAllocationPolicyAbstract extends VmAllocationPolicy
 
     @Override
     public PowerHost findHostForVm(Vm vm) {
-        return this.<PowerHost>getHostList().stream()
-            .filter(h -> h.isSuitableForVm(vm))
-            .findFirst().orElse(PowerHost.NULL);
+        return this.<PowerHost>getHostList()
+                .stream()
+                .sorted()
+                .filter(h -> h.isSuitableForVm(vm))
+                .findFirst().orElse(PowerHost.NULL);
     }
 
     @Override
     public void deallocateHostForVm(Vm vm) {
-        Host host = getVmHostMap().remove(vm);
+        Host host = removeVmFromHostMap(vm);
         if (!Objects.isNull(host)) {
             host.destroyVm(vm);
         }
     }
 
-    /**
-     * Gets the map where each key is a VM UID and
-     * each value is the host where the VM is placed.
-     *
-     * @return
-     */
-    public Map<Vm, Host> getVmHostMap() {
-        return vmHostMap;
-    }
-
+    
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/power/PowerVmAllocationPolicyMigrationAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/power/PowerVmAllocationPolicyMigrationAbstract.java
@@ -507,7 +507,7 @@ public abstract class PowerVmAllocationPolicyMigrationAbstract extends PowerVmAl
                         "Couldn't restore VM #%d on host #%d",
                         vm.getId(), host.getId()));
             }
-            getVmHostMap().put(vm, host);
+            addVmToHostMap(vm, host);
         }
     }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -191,9 +191,9 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
         vmsWaitingList.addAll(list);
 
         if (isStarted() && !list.isEmpty()) {
-            Log.printFormattedLine(
+            println(String.format(
                 "%.2f: %s: List of %d VMs submitted to the broker during simulation execution.\n\t VMs creation request sent to Datacenter.",
-                getSimulation().clock(), getName(), list.size());
+                getSimulation().clock(), getName(), list.size()));
             requestDatacenterToCreateWaitingVms();
         }
     }
@@ -301,19 +301,19 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
             return;
         }
 
-        Log.printFormattedLine(
+        println(String.format(
             "%.2f: %s: List of %d Cloudlets submitted to the broker during simulation execution.",
-            getSimulation().clock(), getName(), list.size());
+            getSimulation().clock(), getName(), list.size()));
 
         //If there aren't more VMs to be created, then request Cloudlets creation
         if(getVmsWaitingList().isEmpty()){
-            Log.printLine(" Cloudlets creation request sent to Datacenter.");
+            println(" Cloudlets creation request sent to Datacenter.");
             requestDatacentersToCreateWaitingCloudlets();
             notifyOnCreationOfWaitingVmsFinishListeners();
         } else
-            Log.printFormattedLine(
+            println(String.format(
                     " Waiting creation of %d VMs to send Cloudlets creation request to Datacenter.",
-                    getVmsWaitingList().size());
+                    getVmsWaitingList().size()));
     }
 
     private void sortCloudletsIfComparatorIsSet(List<? extends Cloudlet> list) {
@@ -412,9 +412,9 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
      */
     protected void processDatacenterListRequest(SimEvent ev) {
         setDatacenterList((Set<Datacenter>) ev.getData());
-        Log.printFormattedLine(
+        println(String.format(
             "%.2f: %s: List of Datacenters received with %d datacenters(s).",
-            getSimulation().clock(), getName(), getDatacenterList().size());
+            getSimulation().clock(), getName(), getDatacenterList().size()));
         requestDatacenterToCreateWaitingVms();
     }
 
@@ -487,8 +487,8 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
         /* If it gets here, it means that all datacenters were already queried
          * and not all VMs could be created, but some of them could. */
         if (getVmsCreatedList().isEmpty()) {
-            Log.printFormattedLine("%.2f: %s: %s", getSimulation().clock(), getName(),
-                "none of the required VMs could be created. Aborting");
+            println(String.format("%.2f: %s: %s", getSimulation().clock(), getName(),
+                "none of the required VMs could be created. Aborting"));
             finishExecution();
             return;
         }
@@ -523,9 +523,9 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
         getVmsToDatacentersMap().put(vm, datacenter);
         vmsWaitingList.remove(vm);
         getVmsCreatedList().add(vm);
-        Log.printFormattedLine(
+        println(String.format(
             "%.2f: %s: %s has been created in %s.",
-            getSimulation().clock(), getName(), vm, vm.getHost());
+            getSimulation().clock(), getName(), vm, vm.getHost()));
     }
 
     /**
@@ -537,9 +537,9 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
      */
     protected void processFailedVmCreationInDatacenter(Vm vm, Datacenter datacenter) {
         vm.notifyOnCreationFailureListeners(datacenter);
-        Log.printFormattedLine(
+        println(String.format(
             "%.2f: %s: Creation of %s failed in Datacenter #%s",
-            getSimulation().clock(), getName(), vm, datacenter.getId());
+            getSimulation().clock(), getName(), vm, datacenter.getId()));
     }
 
     /**
@@ -552,14 +552,14 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
     protected void processCloudletReturn(SimEvent ev) {
         final Cloudlet cloudlet = (Cloudlet) ev.getData();
         cloudletsFinishedList.add(cloudlet);
-        Log.printFormattedLine("%.2f: %s: %s %d finished and returned to broker.",
-            getSimulation().clock(), getName(), cloudlet.getClass().getSimpleName(), cloudlet.getId());
+        println(String.format("%.2f: %s: %s %d finished and returned to broker.",
+            getSimulation().clock(), getName(), cloudlet.getClass().getSimpleName(), cloudlet.getId()));
         cloudletsCreated--;
         if (getCloudletsWaitingList().isEmpty() && cloudletsCreated == 0) {
             // all cloudlets executed
-            Log.printFormattedLine(
+            println(String.format(
                 "%.2f: %s: All Cloudlets executed. Finishing...",
-                getSimulation().clock(), getName());
+                getSimulation().clock(), getName()));
             destroyVms();
             finishExecution();
         } else if (hasMoreCloudletsToBeExecuted()) {
@@ -586,10 +586,10 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
      */
     protected void processOtherEvent(SimEvent ev) {
         if (Objects.isNull(ev)) {
-            Log.printConcatLine(getName(), ".processOtherEvent(): ", "Error - an event is null.");
+            println(String.format("%s.processOtherEvent(): Error - an event is null.", getName()));
             return;
         }
-        Log.printConcatLine(getName(), ".processOtherEvent(): Error - event unknown by this DatacenterBroker.");
+        println(String.format("%s.processOtherEvent(): Error - event unknown by this DatacenterBroker.", getName()));
     }
 
     /**
@@ -619,9 +619,9 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
         int requestedVms = 0;
         for (final Vm vm : getVmsWaitingList()) {
             if (!vmsToDatacentersMap.containsKey(vm) && !vmCreationRequestsMap.containsKey(vm)) {
-                Log.printFormattedLine(
+                println(String.format(
                     "%.2f: %s: Trying to Create %s in %s",
-                    getSimulation().clock(), getName(), vm, datacenter.getName());
+                    getSimulation().clock(), getName(), vm, datacenter.getName()));
                 sendNow(datacenter.getId(), CloudSimTags.VM_CREATE_ACK, vm);
                 vmCreationRequestsMap.put(vm, datacenter);
                 requestedVms++;
@@ -657,15 +657,15 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
             lastSelectedVm = vmMapper.apply(cloudlet);
             if (lastSelectedVm == Vm.NULL) {
                 // vm was not created
-                Log.printFormattedLine(
+                println(String.format(
                     "%.2f: %s: : Postponing execution of cloudlet %d: bind VM not available.",
-                    getSimulation().clock(), getName(), cloudlet.getId());
+                    getSimulation().clock(), getName(), cloudlet.getId()));
                 continue;
             }
-            Log.printFormattedLine(
+            println(String.format(
                 "%.2f: %s: Sending %s %d to %s in %s.",
                 getSimulation().clock(), getName(), cloudlet.getClass().getSimpleName(), cloudlet.getId(),
-                lastSelectedVm, lastSelectedVm.getHost());
+                lastSelectedVm, lastSelectedVm.getHost()));
             cloudlet.setVm(lastSelectedVm);
             send(getVmDatacenter(lastSelectedVm).getId(),
                 cloudlet.getSubmissionDelay(), CloudSimTags.CLOUDLET_SUBMIT, cloudlet);
@@ -685,7 +685,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
      */
     protected void destroyVms() {
         for (final Vm vm : getVmsCreatedList()) {
-            Log.printFormattedLine("%.2f: %s: Destroying %s", getSimulation().clock(), getName(), vm);
+            println(String.format("%.2f: %s: Destroying %s", getSimulation().clock(), getName(), vm));
             sendNow(getVmDatacenter(vm).getId(), CloudSimTags.VM_DESTROY, vm);
         }
         getVmsCreatedList().clear();
@@ -703,12 +703,12 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
 
     @Override
     public void shutdownEntity() {
-        Log.printConcatLine(getName(), " is shutting down...");
+        println(String.format("%s is shutting down...", getName()));
     }
 
     @Override
     public void startEntity() {
-        Log.printConcatLine(getName(), " is starting...");
+        println(String.format("%s is starting...", getName()));
         schedule(getSimulation().getCloudInfoServiceEntityId(), 0, CloudSimTags.DATACENTER_LIST_REQUEST);
     }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/PeNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/PeNull.java
@@ -59,6 +59,7 @@ final class PeNull implements Pe {
     @Override public boolean deallocateResource(long amountToDeallocate) {
         return false;
     }
+    @Override public boolean deallocateAndRemoveResource(long amountToDeallocate) { return false; }
     @Override public long deallocateAllResources() {
         return 0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/Processor.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/Processor.java
@@ -192,7 +192,7 @@ public final class Processor extends ResourceManageableAbstract {
     /**
      * Sets the number of {@link Pe}s of the Processor
      * @param numberOfPes the number of PEs to set
-     * @return 
+     * @return
      */
     @Override
     public final boolean setCapacity(long numberOfPes) {
@@ -260,11 +260,6 @@ public final class Processor extends ResourceManageableAbstract {
     @Override
     public boolean allocateResource(long amountToAllocate) {
         throw new UnsupportedOperationException("The allocateResource method is not supported for the Processor because this is controlled by the CloudletScheduler.");
-    }
-
-    @Override
-    public boolean deallocateResource(long amountToDeallocate) {
-        throw new UnsupportedOperationException("The deallocateResource method is not supported for the Processor because this is controlled by the CloudletScheduler.");
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageable.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageable.java
@@ -28,7 +28,7 @@ public interface ResourceManageable extends Resource {
      * Try to set the {@link #getCapacity() resource capacity}.
      *
      * @param newCapacity the new resource capacity
-     * @return true if capacity > 0 and capacity >= current allocated resource,
+     * @return true if capacity >= 0 and capacity >= current allocated resource,
      * false otherwise
      * @see #getAllocatedResource()
      */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageable.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageable.java
@@ -120,6 +120,20 @@ public interface ResourceManageable extends Resource {
     boolean deallocateResource(long amountToDeallocate);
 
     /**
+     * Try to deallocate a given amount of the resource and then
+     * remove such amount from the total capacity.
+     * If the given amount is greater than the total allocated resource,
+     * all the resource will be deallocated and that amount
+     * will be removed from the total capacity.
+     *
+     * @param amountToDeallocate the amount of resource to be deallocated and then removed from
+     *                           the total capacity
+     * @return true if amountToDeallocate > 0 and there is enough resource to
+     * deallocate, false otherwise
+     */
+    boolean deallocateAndRemoveResource(long amountToDeallocate);
+
+    /**
      * Try to deallocate all the capacity of the given resource from this resource.
      * This method is commonly used to deallocate a specific
      * amount of a physical resource (this Resource instance)

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageableAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageableAbstract.java
@@ -121,6 +121,19 @@ public abstract class ResourceManageableAbstract extends ResourceAbstract implem
     }
 
     @Override
+    public boolean deallocateAndRemoveResource(long amountToDeallocate) {
+        final long amountToRemoveFromSize = amountToDeallocate;
+        //cannot deallocate more than it's allocated
+        amountToDeallocate = Math.min(amountToDeallocate, this.getAllocatedResource());
+        if(amountToDeallocate != 0 && !deallocateResource(amountToDeallocate)){
+            return false;
+        }
+
+        return removeCapacity(amountToRemoveFromSize);
+
+    }
+
+    @Override
     public boolean deallocateResource(final long amountToDeallocate) {
         if(amountToDeallocate <= 0 || !isResourceAmountBeingUsed(amountToDeallocate)) {
             return false;
@@ -132,7 +145,7 @@ public abstract class ResourceManageableAbstract extends ResourceAbstract implem
 
     @Override
     public long deallocateAllResources() {
-        final Long previousAllocated = getAllocatedResource();
+        final long previousAllocated = getAllocatedResource();
         setAvailableResource(getCapacity());
         return previousAllocated;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageableAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageableAbstract.java
@@ -34,7 +34,7 @@ public abstract class ResourceManageableAbstract extends ResourceAbstract implem
 
     @Override
     public boolean setCapacity(long newCapacity){
-        if(newCapacity <= 0 || getAllocatedResource() > newCapacity) {
+        if(newCapacity < 0 || getAllocatedResource() > newCapacity) {
             return false;
         }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageableNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/ResourceManageableNull.java
@@ -22,6 +22,7 @@ final class ResourceManageableNull implements ResourceManageable {
     @Override public boolean deallocateResource(long amountToDeallocate) {
         return false;
     }
+    @Override public boolean deallocateAndRemoveResource(long amountToDeallocate) { return false; }
     @Override public long deallocateAllResources() {
         return 0L;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletScheduler.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletScheduler.java
@@ -197,17 +197,6 @@ public interface CloudletScheduler extends Serializable {
     double getAllocatedMipsForCloudlet(CloudletExecutionInfo rcl, double time);
 
     /**
-     * Gets the total current mips that a Cloudlet can use for each PE
-     * it requires. Thus, the value returned by the method indicates the
-     * amount of MIPS each Cloudlet PE can use.
-     *
-     * @param rcl the rcl
-     * @param mipsShare the mips share
-     * @return the total current mips available for each Cloudlet PE
-     */
-    double getTotalCurrentAvailableMipsForCloudlet(CloudletExecutionInfo rcl, List<Double> mipsShare);
-
-    /**
      * Gets the current requested MIPS for a given cloudlet.
      *
      * @param rcl the rcl

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -12,6 +12,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import static java.util.stream.Collectors.toList;
+
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
@@ -59,10 +61,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      */
     private PacketScheduler packetScheduler;
     /**
-     * @see #getProcessor()
-     */
-    private Processor processor;
-    /**
      * @see #getUsedPes()
      */
     private int usedPes;
@@ -102,7 +100,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      */
     public CloudletSchedulerAbstract() {
         setPreviousTime(0.0);
-        processor = new Processor();
         usedPes = 0;
         vm = Vm.NULL;
         cloudletExecList = new ArrayList<>();
@@ -147,7 +144,54 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
             Log.printFormattedLine("Requested %d PEs but %s has just %d", currentMipsShare.size(), vm, vm.getNumberOfPes());
         }
         this.currentMipsShare = currentMipsShare;
-        processor = Processor.fromMipsList(vm, currentMipsShare, getCloudletExecList());
+    }
+
+
+    /**
+     * Gets the amount of MIPS available (free) for each Processor PE,
+     * considering the currently executing cloudlets in this processor
+     * and the number of PEs these cloudlets require.
+     * This is the amount of MIPS that each Cloudlet is allowed to used,
+     * considering that the processor is shared among all executing
+     * cloudlets.
+     *
+     * <p>In the case of space shared schedulers,
+     * there is no concurrency for PEs because some cloudlets
+     * may wait in a queue until there is available PEs to be used
+     * exclusively by them.</p>
+     *
+     * @return the amount of available MIPS for each Processor PE.
+     * @TODO Splitting the capacity of a CPU core among different applications
+     * is not in fact possible. This was just an oversimplification
+     * performed by the CloudletSchedulerTimeShared that may affect
+     * other schedulers such as the CloudletSchedulerCompletelyFair
+     * that in fact performs tasks preemption.
+     */
+    public double getAvailableMipsByPe(){
+        final long totalPesOfAllExecCloudlets = totalPesOfAllExecCloudlets();
+        if(totalPesOfAllExecCloudlets > currentMipsShare.size()) {
+            return getTotalMipsShare() / totalPesOfAllExecCloudlets;
+        }
+
+        return getPeCapacity();
+    }
+
+    private Double getPeCapacity() {
+        return currentMipsShare.stream().findFirst().orElse(0.0);
+    }
+
+    /**
+     * Gets the total number of PEs of all cloudlets currently executing in this processor.
+     * @return
+     */
+    private long totalPesOfAllExecCloudlets() {
+        return cloudletExecList.stream()
+            .map(CloudletExecutionInfo::getCloudlet)
+            .mapToLong(Cloudlet::getNumberOfPes).sum();
+    }
+
+    private double getTotalMipsShare(){
+        return currentMipsShare.stream().reduce(0.0, Double::sum);
     }
 
     @Override
@@ -237,7 +281,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
             rcl.setCloudletStatus(Status.INEXEC);
             rcl.setFileTransferTime(fileTransferTime);
             addCloudletToExecList(rcl);
-            return fileTransferTime + (rcl.getCloudletLength() / getProcessor().getMips());
+            return fileTransferTime + (rcl.getCloudletLength() / getPeCapacity());
         }
 
         // No enough free PEs, then add Cloudlet to the waiting queue
@@ -471,35 +515,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
     }
 
     /**
-     * Updates the VM usage of RAM, based on the current utilization of all
-     * its running Cloudlets, that depends on the {@link Cloudlet#getUtilizationModelRam()}.
-     */
-    private void updateVmRamAbsoluteUtilization() {
-        final ResourceManageable ram = vm.getResource(Ram.class);
-        final double totalUsedRam = getCloudletExecList().stream()
-            .map(CloudletExecutionInfo::getCloudlet)
-            .mapToDouble(this::getCloudletRamAbsoluteUtilization)
-            .sum();
-
-        ram.setAllocatedResource(totalUsedRam);
-    }
-
-    /**
-     * Gets the absolute value of RAM utilization for a given Cloudlet
-     *
-     * @param cloudlet the Cloudlet to get the absolute value of RAM utilization
-     * @return the Cloudlet RAM utilization in absolute value
-     */
-    private double getCloudletRamAbsoluteUtilization(Cloudlet cloudlet) {
-        final ResourceManageable ram = vm.getResource(Ram.class);
-        final UtilizationModel um = cloudlet.getUtilizationModelRam();
-        final double utilization = um.getUnit() == Unit.ABSOLUTE ?
-            Math.min(um.getUtilization(), vm.getRam().getCapacity()) :
-            um.getUtilization() * ram.getCapacity();
-        return utilization;
-    }
-
-    /**
      * Updates the processing of a specific cloudlet of the Vm using this
      * scheduler and packets that such a Cloudlet has to send or to receive
      * (if the CloudletScheduler has a {@link PacketScheduler} assigned to it).
@@ -528,6 +543,35 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
         if (executedInstructions > 0) {
             rcl.setLastProcessingTime(currentTime);
         }
+    }
+
+    /**
+     * Updates the VM usage of RAM, based on the current utilization of all
+     * its running Cloudlets, that depends on the {@link Cloudlet#getUtilizationModelRam()}.
+     */
+    private void updateVmRamAbsoluteUtilization() {
+        final ResourceManageable ram = vm.getResource(Ram.class);
+        final double totalUsedRam = getCloudletExecList().stream()
+            .map(CloudletExecutionInfo::getCloudlet)
+            .mapToDouble(this::getCloudletRamAbsoluteUtilization)
+            .sum();
+
+        ram.setAllocatedResource(totalUsedRam);
+    }
+
+    /**
+     * Gets the absolute value of RAM utilization for a given Cloudlet
+     *
+     * @param cloudlet the Cloudlet to get the absolute value of RAM utilization
+     * @return the Cloudlet RAM utilization in absolute value
+     */
+    private double getCloudletRamAbsoluteUtilization(Cloudlet cloudlet) {
+        final ResourceManageable ram = vm.getResource(Ram.class);
+        final UtilizationModel um = cloudlet.getUtilizationModelRam();
+        final double utilization = um.getUnit() == Unit.ABSOLUTE ?
+            Math.min(um.getUtilization(), vm.getRam().getCapacity()) :
+            um.getUtilization() * ram.getCapacity();
+        return utilization;
     }
 
     /**
@@ -567,7 +611,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
         final double actualProcessingTime = (hasCloudletFileTransferTimePassed(rcl, currentTime) ? timeSpan(currentTime) : 0);
         final double cloudletUsedMips =
             getAbsoluteCloudletResourceUtilization(rcl.getCloudlet().getUtilizationModelCpu(),
-                currentTime, processor.getAvailableMipsByPe());
+                currentTime, getAvailableMipsByPe());
         return (long) (cloudletUsedMips * actualProcessingTime * Conversion.MILLION);
     }
 
@@ -676,7 +720,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
     protected double getEstimatedFinishTimeOfCloudlet(CloudletExecutionInfo rcl, double currentTime) {
         final double cloudletUsedMips =
             getAbsoluteCloudletResourceUtilization(rcl.getCloudlet().getUtilizationModelCpu(),
-                currentTime, processor.getAvailableMipsByPe());
+                currentTime, getAvailableMipsByPe());
         double estimatedFinishTime = rcl.getRemainingCloudletLength() / cloudletUsedMips;
 
         if (estimatedFinishTime < getVm().getSimulation().getMinTimeBetweenEvents()) {
@@ -723,7 +767,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      * @return true if there is the amount of free PEs, false otherwise
      */
     protected boolean isThereEnoughFreePesForCloudlet(CloudletExecutionInfo c) {
-        return processor.getCapacity() - usedPes >= c.getNumberOfPes();
+        return currentMipsShare.size() - usedPes >= c.getNumberOfPes();
     }
 
     /**
@@ -746,17 +790,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
         c.setCloudletStatus(Status.INEXEC);
         removeCloudletFromWaitingList(c);
         return c;
-    }
-
-    /**
-     * Processor object created every time the processing of VMs is executed. It
-     * represent the last CPU capacity assigned to the scheduler.
-     *
-     * @return
-     * @see CloudletScheduler#updateProcessing(double, List)
-     */
-    protected Processor getProcessor() {
-        return processor;
     }
 
     @Override
@@ -806,7 +839,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      */
     @Override
     public long getFreePes() {
-        return getProcessor().getCapacity() - getUsedPes();
+        return currentMipsShare.size() - getUsedPes();
     }
 
     /**
@@ -863,7 +896,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
     private double getAbsoluteCloudletCpuUtilizationForAllPes(double time, Cloudlet cloudlet) {
         final double cloudletCpuUsageForOnePe =
             getAbsoluteCloudletResourceUtilization(
-                cloudlet.getUtilizationModelCpu(), time, processor.getAvailableMipsByPe());
+                cloudlet.getUtilizationModelCpu(), time, getAvailableMipsByPe());
 
         return cloudletCpuUsageForOnePe * cloudlet.getNumberOfPes();
     }
@@ -875,7 +908,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
 
     @Override
     public double getAllocatedMipsForCloudlet(CloudletExecutionInfo rcl, double time) {
-        return getAbsoluteCloudletResourceUtilization(rcl.getCloudlet().getUtilizationModelCpu(), time, getProcessor().getAvailableMipsByPe());
+        return getAbsoluteCloudletResourceUtilization(rcl.getCloudlet().getUtilizationModelCpu(), time, getAvailableMipsByPe());
     }
 
     @Override
@@ -943,7 +976,12 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
     @Override
     public void deallocatePesFromVm(Vm vm, int pesToRemove) {
         removeUsedPes(pesToRemove);
-        processor.deallocateAndRemoveResource(pesToRemove);
+        deallocatePesFromMipsShare(pesToRemove);
+    }
+
+    private void deallocatePesFromMipsShare(int pesToRemove) {
+        pesToRemove = Math.min(pesToRemove, currentMipsShare.size());
+        IntStream.range(0, pesToRemove).forEach(i -> currentMipsShare.remove(0));
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -24,6 +24,7 @@ import org.cloudbus.cloudsim.util.Conversion;
 
 import static org.cloudbus.cloudsim.utilizationmodels.UtilizationModel.Unit;
 
+import org.cloudbus.cloudsim.util.Log;
 import org.cloudbus.cloudsim.utilizationmodels.UtilizationModel;
 import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudbus.cloudsim.resources.Processor;
@@ -142,6 +143,9 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      * @see #getCurrentMipsShare()
      */
     protected void setCurrentMipsShare(List<Double> currentMipsShare) {
+        if(currentMipsShare.size() > vm.getNumberOfPes()){
+            Log.printFormattedLine("Requested %d PEs but %s has just %d", currentMipsShare.size(), vm, vm.getNumberOfPes());
+        }
         this.currentMipsShare = currentMipsShare;
         processor = Processor.fromMipsList(vm, currentMipsShare, getCloudletExecList());
     }
@@ -149,10 +153,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
     @Override
     public List<CloudletExecutionInfo> getCloudletExecList() {
         return Collections.unmodifiableList(cloudletExecList);
-    }
-
-    protected final void setCloudletExecList(List<CloudletExecutionInfo> cloudletExecList) {
-        this.cloudletExecList = cloudletExecList;
     }
 
     protected void addCloudletToWaitingList(CloudletExecutionInfo cloudlet) {
@@ -206,10 +206,6 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      */
     protected void sortCloudletWaitingList(Comparator<CloudletExecutionInfo> comparator){
         cloudletWaitingList.sort(comparator);
-    }
-
-    protected final void setCloudletWaitingList(List<CloudletExecutionInfo> cloudletWaitingList) {
-        this.cloudletWaitingList = cloudletWaitingList;
     }
 
     @Override
@@ -829,7 +825,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
      *                        PEs
      */
     private void removeUsedPes(long usedPesToRemove) {
-        this.usedPes -= usedPesToRemove;
+        this.usedPes = (int)Math.max(0, this.usedPes-usedPesToRemove);
     }
 
     @Override
@@ -946,8 +942,8 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
 
     @Override
     public void deallocatePesFromVm(Vm vm, int pesToRemove) {
-        processor.removeCapacity(pesToRemove);
         removeUsedPes(pesToRemove);
+        processor.deallocateAndRemoveResource(pesToRemove);
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerNull.java
@@ -42,9 +42,6 @@ final class CloudletSchedulerNull implements CloudletScheduler {
     @Override public List<Double> getCurrentMipsShare() {
         return Collections.emptyList();
     }
-    public List<Double> getCurrentRequestedMips() {
-        return Collections.emptyList();
-    }
     @Override public double getCurrentRequestedBwPercentUtilization() {
         return 0.0;
     }
@@ -57,7 +54,6 @@ final class CloudletSchedulerNull implements CloudletScheduler {
     @Override public double getAllocatedMipsForCloudlet(CloudletExecutionInfo rcl, double time) {
         return 0.0;
     }
-    @Override public double getTotalCurrentAvailableMipsForCloudlet(CloudletExecutionInfo rcl, List<Double> mipsShare) { return 0.0; }
     @Override public double getRequestedMipsForCloudlet(CloudletExecutionInfo rcl, double time) {
         return 0.0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerSpaceShared.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerSpaceShared.java
@@ -81,21 +81,6 @@ public class CloudletSchedulerSpaceShared extends CloudletSchedulerAbstract {
     }
 
     /**
-     * {@inheritDoc}
-     * <p>
-     * It doesn't consider the given Cloudlet because the scheduler ensures that
-     * the Cloudlet will use all required PEs until it finishes executing. </p>
-     *
-     * @param rcl {@inheritDoc}
-     * @param mipsShare {@inheritDoc}
-     * @return {@inheritDoc}
-     */
-    @Override
-    public double getTotalCurrentAvailableMipsForCloudlet(CloudletExecutionInfo rcl, List<Double> mipsShare) {
-        return Processor.fromMipsList(getVm(), mipsShare).getMips();
-    }
-
-    /**
      * The space-shared scheduler <b>does not</b> share the CPU time between
      * executing cloudlets. Each CPU ({@link Pe}) is used by another Cloudlet
      * just when the previous Cloudlet using it has finished executing

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerTimeShared.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerTimeShared.java
@@ -113,25 +113,6 @@ public class CloudletSchedulerTimeShared extends CloudletSchedulerAbstract {
     }
 
     /**
-     * {@inheritDoc} It in fact doesn't consider the parameters given because in
-     * the Time Shared Scheduler, the CPU capacity from the VM that is managed
-     * by the scheduler is shared between all running cloudlets.
-     *
-     * @todo if there is 2 cloudlets requiring 1 PE and there is just 1 PE, the
-     * MIPS capacity of this PE is split between the 2 cloudlets, but the method
-     * seen to always return the entire capacity. New test cases have to be
-     * created to check this.
-     *
-     * @param rcl {@inheritDoc}
-     * @param mipsShare {@inheritDoc}
-     * @return {@inheritDoc}
-     */
-    @Override
-    public double getTotalCurrentAvailableMipsForCloudlet(CloudletExecutionInfo rcl, List<Double> mipsShare) {
-        return Processor.fromMipsList(getVm(), mipsShare).getMips();
-    }
-
-    /**
      * This time-shared scheduler shares the CPU time between all executing
      * cloudlets, giving the same CPU timeslice for each Cloudlet to execute. It
      * always allow any submitted Cloudlets to be immediately added to the

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/faultinjection/HostFaultInjection.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/faultinjection/HostFaultInjection.java
@@ -177,8 +177,13 @@ public class HostFaultInjection extends CloudSimEntity {
     private int numberOfHostFaults;
 
     /**
-     * A map to store the time (in seconds) each failed VM took to be recovered.
-     * It also means the failure time for each Vm.
+     * A map to store the time (in seconds) VM failures took to be recovered,
+     * which is when a clone from the last failed VM for a given broker is created.
+     * Since a broker just creates a VM clone when all its VMs have failed,
+     * only at that time the failure is in fact recovered.
+     *
+     * It means the time period failure of all VMs persisted
+     * before a clone was created.
      */
     private final Map<Vm, Double> vmRecoveryTimeMap;
 
@@ -484,7 +489,6 @@ public class HostFaultInjection extends CloudSimEntity {
         vm.setFailed(true);
         final DatacenterBroker broker = vm.getBroker();
         if(isVmClonerSet(broker) && isAllVmsFailed(broker)){
-
             final double recoveryTime = getRandomRecoveryTimeForVm();
             Log.printFormattedLine("\t# Time to recovery the fault: %.2f minutes", recoveryTime/60);
             vmRecoveryTimeMap.put(vm, recoveryTime);

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/faultinjection/HostFaultInjection.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/faultinjection/HostFaultInjection.java
@@ -48,6 +48,10 @@ import org.cloudbus.cloudsim.distributions.PoissonDistr;
 /**
  * Generates random failures for the {@link Pe}'s of {@link Host}s
  * inside a given {@link Datacenter}.
+ * A Fault Injection object
+ * usually has to be created after the VMs are created,
+ * to make it easier to define a function to be used
+ * to clone failed VMs.
  *
  * The events happens in the following order:
  * <ol>
@@ -121,6 +125,10 @@ import org.cloudbus.cloudsim.distributions.PoissonDistr;
  * @author raysaoliveira
  * @since CloudSim Plus 1.2.0
  * @see <a href="https://blogs.sap.com/2014/07/21/equipment-availability-vs-reliability/">SAP Blog: Availability vs Reliability</a>
+ *
+ * @todo The class has multiple responsibilities.
+ * The fault injection mechanism must be separated from
+ * the fault recovery. The cloner methods are fault recovery.
  */
 public class HostFaultInjection extends CloudSimEntity {
     /**
@@ -138,23 +146,15 @@ public class HostFaultInjection extends CloudSimEntity {
      * and the number of PEs to set as fail.
      */
     private ContinuousDistribution random;
-    
-    /**
-     * A Pseudo Random Number Generator used to give a 
-     * recovery time for each vm that was failed.
-     */
-    private ContinuousDistribution randomRecoveryTimeForVm;
 
     /**
-     * @see #setVmCloner(java.util.function.UnaryOperator)
+     * A map that stores a {@link Function} to be used to clone
+     * a VM. If a VM isn't in this map, it will not
+     * be cloned in case of failure.
      *
-     * @todo The class has multiple responsibilities.
-     * The fault injection mechanism must be separated from
-     * the fault recovery.
-     * The cloner methods are fault recovery.
-     *
+     * @see #setVmCloner(org.cloudbus.cloudsim.vms.Vm, java.util.function.UnaryOperator)
      */
-    private UnaryOperator<Vm> vmCloner;
+    private Map<Vm, UnaryOperator<Vm>> vmClonerMap;
 
     /**
      * @see #setCloudletsCloner(java.util.function.Function)
@@ -171,13 +171,13 @@ public class HostFaultInjection extends CloudSimEntity {
      * The attribute counts how many host failures the simulation had
      */
     private int numberOfHostFaults;
-    
+
     /**
      * A map to store the time (in seconds) each failed VM took to be recovered.
      * It also means the failure time for each Vm.
      */
     private final Map<Vm, Double> vmRecoveryTimeMap;
-    
+
     /**
      * A map to store the times (in seconds) for each Host failure.
      */
@@ -185,16 +185,24 @@ public class HostFaultInjection extends CloudSimEntity {
 
     /**
      * A function that in fact doesn't clone any VM.
-     * The {@link #vmCloner} is initialized with this function to avoid {@code NullPointerException}
-     * if the attribute is not set.
-     */
-    private static final Function<Vm, List<Cloudlet>> CLOUDLETS_CLONER_NULL = vm -> Collections.EMPTY_LIST;
-    /**
-     * A function that in fact doesn't clone cloudlets.
      * The {@link #cloudletsCloner} is initialized with this function to avoid {@code NullPointerException}
      * if the attribute is not set.
      */
+    private static final Function<Vm, List<Cloudlet>> CLOUDLETS_CLONER_NULL = vm -> Collections.EMPTY_LIST;
+
+    /**
+     * A function that in fact doesn't clone VMs.
+     * It's used as the default value when a VM doesn't have a cloner function.
+     */
     private static final UnaryOperator<Vm> VM_CLONER_NULL = vm -> Vm.NULL;
+
+    /**
+     * Maximum number of seconds for a VM to recovery from a failure,
+     * which is randomly selected based on this value.
+     * The recovery time is the delay that will be set
+     * to start a clone from a failed VM.
+     */
+    private static final int MAX_VM_RECOVERY_TIME_SECS = 1800;
 
     /**
      * Creates a fault injection mechanism for the Hosts of a given {@link Datacenter}.
@@ -217,17 +225,16 @@ public class HostFaultInjection extends CloudSimEntity {
         this.lastFailedHost = Host.NULL;
         this.faultArrivalTimesGenerator = faultArrivalTimesGenerator;
         this.random = new UniformDistr(faultArrivalTimesGenerator.getSeed()+1);
-        this.randomRecoveryTimeForVm = new UniformDistr(1, 1800, faultArrivalTimesGenerator.getSeed()+2);
         this.vmRecoveryTimeMap = new HashMap<>();
         this.hostFaultsTimeMap = new HashMap<>();
 
-        /*Sets a default vmCloner which in fact doesn't
-        clone a VM, just returns the Vm.NULL object.
-        This is used just to ensure that if a vmClone
+        this.vmClonerMap = new HashMap<>();
+
+        /*Sets a default cloudletCloner which in fact doesn't
+        clone anything, just returns an empty List.
+        This is used just to ensure that if a clone function
         is not set, it wont be thrown a NullPointerException
-        and no VM will be cloned.
-        A similar thing is made to the cloudletsCloner below.*/
-        this.vmCloner = VM_CLONER_NULL;
+        when trying to use it.*/
         this.cloudletsCloner = CLOUDLETS_CLONER_NULL;
     }
 
@@ -291,7 +298,7 @@ public class HostFaultInjection extends CloudSimEntity {
 
             numberOfHostFaults++;
             registerHostFaultTime();
-        
+
             final int numberOfPesToFail = generateHostPesFaults();
             final long hostWorkingPes = lastFailedHost.getNumberOfWorkingPes();
             final long vmsRequiredPes = getPesSumOfWorkingVms();
@@ -334,7 +341,10 @@ public class HostFaultInjection extends CloudSimEntity {
         if (datacenter.getHostList().isEmpty()) {
             return Host.NULL;
         }
-        return datacenter.getHost((int) (random.sample() * datacenter.getHostList().size()));
+
+        final int i = (int) (random.sample() * datacenter.getHostList().size());
+        System.out.printf("\t\t#%.2f: Random Host: %s Position: %d\n", getSimulation().clock(), datacenter.getHost(i), i);
+        return datacenter.getHost(i);
     }
 
     /**
@@ -381,7 +391,7 @@ public class HostFaultInjection extends CloudSimEntity {
         final int hostWorkingPes = (int)lastFailedHost.getNumberOfWorkingPes();
         final int vmsRequiredPes = (int)getPesSumOfWorkingVms();
         int failedPesToRemoveFromVms = vmsRequiredPes-hostWorkingPes;
-        
+
         return failedPesToRemoveFromVms;
     }
 
@@ -396,7 +406,7 @@ public class HostFaultInjection extends CloudSimEntity {
         int failedPesToRemoveFromVms = numberOfFailedPesToRemoveFromVms();
         List<Vm> vmsWithPes = getVmsWithPEsFromFailedHost();
         final int affectedVms = Math.min(vmsWithPes.size(), failedPesToRemoveFromVms);
-        
+
         Log.printFormattedLine("\t%d VMs affected from a total of %d. %d PEs are going to be removed from VMs",
                 affectedVms, lastFailedHost.getVmList().size(), failedPesToRemoveFromVms);
         int i = 0;
@@ -418,7 +428,7 @@ public class HostFaultInjection extends CloudSimEntity {
 
     /**
      * Gets a List of VMs that have any PE from the {@link #lastFailedHost}.
-     * @return 
+     * @return
      */
     private List<Vm> getVmsWithPEsFromFailedHost() {
         return lastFailedHost
@@ -450,16 +460,20 @@ public class HostFaultInjection extends CloudSimEntity {
         if (Host.NULL.equals(lastFailedHost)) {
             return;
         }
-        
-        final double recoveryTime = randomRecoveryTimeForVm.sample();
-        Log.printFormattedLine("\t# Time to recovery the fault: %.2f minutes", recoveryTime/60);    
 
-        vmRecoveryTimeMap.put(vm, recoveryTime);
-        
         final DatacenterBroker broker = vm.getBroker();
-        final Vm clone = vmCloner.apply(vm);
+        if(isVmClonerSet(vm)){
+            final double recoveryTime = getRandomRecoveryTimeForVm();
+            Log.printFormattedLine("\t# Time to recovery the fault: %.2f minutes", recoveryTime/60);
+            vmRecoveryTimeMap.put(vm, recoveryTime);
 
-        List<Cloudlet> cloudlets = cloudletsCloner.apply(vm);
+            final Vm vmClone = cloneVm(vm);
+            final List<Cloudlet> cloudletsClone = cloudletsCloner.apply(vm);
+
+            vmClone.setSubmissionDelay(recoveryTime);
+            broker.submitVm(vmClone);
+            broker.submitCloudletList(cloudletsClone, vmClone, recoveryTime);
+        }
         vm.setFailed(true);
 
         /*
@@ -467,84 +481,99 @@ public class HostFaultInjection extends CloudSimEntity {
          it is set here as the sender of the vm destroy request.
          */
         getSimulation().sendNow(
-                vm.getBroker().getId(), datacenter.getId(),
+                broker.getId(), datacenter.getId(),
                 CloudSimTags.VM_DESTROY, vm);
+        Log.printFormattedLine("\n\t\t\t #VM %d destroyd. But not clone\n", vm.getId());
 
-        broker.submitVm(clone);
-        broker.submitCloudletList(cloudlets, clone);
     }
-    
+
+    private boolean isVmClonerSet(Vm vm) {
+        final UnaryOperator<Vm> cloner = vmClonerMap.getOrDefault(vm, VM_CLONER_NULL);
+        return !VM_CLONER_NULL.equals(cloner);
+    }
+
+    /**
+     * Clones a given VM using it's cloner {@link Function} if it was in fact set.
+     *
+     * @param vm the VM to clone
+     * @return the cloned VM or {@link Vm#NULL}
+     * if no cloner function was set
+     */
+    private Vm cloneVm(Vm vm) {
+       return vmClonerMap.getOrDefault(vm, VM_CLONER_NULL).apply(vm);
+    }
+
     /**
      * Gets the total number of faults happened for VMs,
-     * which means the total number of VMs that 
+     * which means the total number of VMs that
      * were destroyed due to failure in Host PEs.
-     * @return 
+     * @return
      */
     public int getNumberOfDestroyedVms() {
         return vmRecoveryTimeMap.size();
-    }    
+    }
 
     /**
      * Gets the total number of faults happened for existing hosts.
      * This isn't the total number of failed hosts because one
      * host may fail multiple times.
-     * @return 
+     * @return
      */
     public int getNumberOfHostFaults() {
         return numberOfHostFaults;
-    }    
+    }
 
     /**
      * Gets the Datacenter's availability as a percentage value between 0 to 1,
      * based on VMs' downtime (the times VMs took to be repaired).
-     * @return 
+     * @return
      */
     public double availability() {
         //no failures means 100% availability
         if(meanTimeBetweenVmFaultsInMinutes() == 0){
             return 1;
         }
-        
+
         return (meanTimeBetweenVmFaultsInMinutes()/(meanTimeBetweenVmFaultsInMinutes() + meanTimeToRepairVmFaultsInMinutes()));
-    }    
-    
+    }
+
     /**
      * Computes the current mean time (in minutes) between Host failures (MTBF).
      * It uses a straightforward way to compute the MTBF.
      * Since it's stored the VM recovery times, it's possible
      * to use such values to make easier the MTBF computation,
      * different from the Hosts MTBF.
-     * 
+     *
      * @return the current mean time (in minutes) between Host failures (MTBF)
      * or zero if no VM was destroyed due to Host failure
-     * @see #meanTimeBetweenHostFaultsInMinutes() 
+     * @see #meanTimeBetweenHostFaultsInMinutes()
      */
     public double meanTimeBetweenVmFaultsInMinutes() {
         if(getNumberOfDestroyedVms() == 0){
             return 0;
         }
-        
+
         return (getSimulation().clockInMinutes() - totalVmsRecoveryTimeInMinutes()) / getNumberOfDestroyedVms();
-    }    
-    
+    }
+
     /**
      * Gets the total time (in minutes) every failed VM took to recovery
-     * from failure. 
-     * @return 
+     * from failure.
+     * @return
      */
     private double totalVmsRecoveryTimeInMinutes() {
         return vmRecoveryTimeMap.values().stream().reduce(0.0, Double::sum) / 60.0;
-    }   
-    
+    }
+
     /**
      * Computes the current mean time (in minutes) between Host failures (MTBF).
      * Since Hosts don't actually recover from failures,
      * there aren't recovery time to make easier the computation
      * of MTBF for Host as it is directly computed for VMs.
-     * 
+     *
      * @return the current mean time (in minutes) between Host failures (MTBF)
      * or zero if no failures have happened yet
-     * @see #meanTimeBetweenVmFaultsInMinutes() 
+     * @see #meanTimeBetweenVmFaultsInMinutes()
      */
     public double meanTimeBetweenHostFaultsInMinutes() {
         final List<Double> values = hostFaultsTimeMap
@@ -556,17 +585,17 @@ public class HostFaultInjection extends CloudSimEntity {
         if(values.isEmpty()){
             return 0;
         }
-        
+
         //computes the differences between failure times t2 - t1
         double sum=0, previous=values.get(0);
         for(Double v: values) {
             sum += (v - previous);
             previous = v;
         }
-        
+
         return (sum/values.size())/60.0;
     }
-    
+
     /**
      * Computes the current mean time (in minutes) to repair VM failures (MTTR).
      * @return the current mean time (in minutes) to repair VM failures (MTTR)
@@ -577,8 +606,8 @@ public class HostFaultInjection extends CloudSimEntity {
             return 0;
         }
         return totalVmsRecoveryTimeInMinutes() / getNumberOfDestroyedVms();
-    }    
-    
+    }
+
     /**
      * Generates random failures for the PEs from the
      * {@link #getLastFailedHost() last failed Host}.
@@ -611,7 +640,6 @@ public class HostFaultInjection extends CloudSimEntity {
      *
      * @return the generated number of failed PEs for the datacenter,
      * between [1 and Number of PEs].
-     *
      */
     private int randomNumberOfFailedPes() {
         /*the random generator return values from [0 to 1]
@@ -643,7 +671,7 @@ public class HostFaultInjection extends CloudSimEntity {
      * Sets a {@link UnaryOperator} that creates a clone of a {@link Vm}
      * when all Host PEs fail or all VM's PEs are deallocated
      * because they have failed.
-     * 
+     *
      * <p>This is optional. If a cloner function is not set,
      * VMs will not be recovered from failures.</p>
      *
@@ -656,22 +684,26 @@ public class HostFaultInjection extends CloudSimEntity {
      * recovery from a failure.
      * </p>
      *
-     * @param vmCloner the VM cloner {@link Function} to set
+     * @param vm the source VM to be cloned using the given cloning function
+     * @param clonerFunction the VM cloner {@link Function} to set
      * @see #setCloudletsCloner(java.util.function.Function)
      */
-    public void setVmCloner(UnaryOperator<Vm> vmCloner) {
-        Objects.requireNonNull(vmCloner);
-        this.vmCloner = vmCloner;
+    public void setVmCloner(Vm vm, UnaryOperator<Vm> clonerFunction) {
+        Objects.requireNonNull(clonerFunction);
+        Objects.requireNonNull(vm);
+        this.vmClonerMap.put(vm, clonerFunction);
     }
 
     /**
-     * Sets a {@link Function} that creates a clone of all Cloudlets
-     * which were running inside a given failed {@link Vm}.
+     * Sets a {@link Function} that will create a clone of all Cloudlets
+     * which were running inside a {@link Vm} after a fail.
+     * The same function is used to clone the cloudlets
+     * of any cloned VM.
      *
      * <p>If a Vm cloner function is not set, setting a cloudlet's cloner function is optional.
      * Since VMs will not be recovered from failures
      * in this situation, cloudlets inside failed VM will not be recovered too.</p>
-     * 
+     *
      * <p>Such a Function is used to re-create and re-submit those Cloudlets
      * to a clone of the failed VM. In this case, all the Cloudlets are
      * recreated from scratch into the cloned VM,
@@ -682,12 +714,9 @@ public class HostFaultInjection extends CloudSimEntity {
      * into this new VM instance.</p>
      *
      * @param cloudletsCloner the cloudlets cloner {@link Function} to set
-     * @see #setVmCloner(java.util.function.UnaryOperator)
+     * @see #setVmCloner(Vm, UnaryOperator)
      */
     public void setCloudletsCloner(Function<Vm, List<Cloudlet>> cloudletsCloner) {
-        if(vmCloner == null || VM_CLONER_NULL.equals(vmCloner)){
-            throw new IllegalArgumentException("A VM Cloner function must be set before setting a Cloudlets Cloner.");
-        }
         Objects.requireNonNull(cloudletsCloner);
         this.cloudletsCloner = cloudletsCloner;
     }
@@ -704,5 +733,14 @@ public class HostFaultInjection extends CloudSimEntity {
 
     @Override
     public void shutdownEntity() {/**/}
+
+    /**
+     * Gets a Pseudo Random Number used to give a
+     * recovery time (in seconds) for each VM that was failed.
+     * @return
+     */
+    public double getRandomRecoveryTimeForVm() {
+        return random.sample()*MAX_VM_RECOVERY_TIME_SECS + 1;
+    }
 
 }

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/resources/ProcessorTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/resources/ProcessorTest.java
@@ -21,16 +21,6 @@ public class ProcessorTest {
     private static final double PE_MIPS = 1000;
     private static final int NUMBER_OF_PES = 2;
 
-    @Test
-    public void testFromMipsList_CheckCloudletList() {
-        final List<Double> mipsList = createMipsList(1);
-        final List<CloudletExecutionInfo> cloudletExecList = createCloudletExecList(1);
-
-        final Processor processor = Processor.fromMipsList(Vm.NULL, mipsList, cloudletExecList);
-        assertEquals("The cloudlet exec list is the same size as expected",
-                cloudletExecList.size(), processor.getCloudletExecList().size());
-    }
-
     private List<CloudletExecutionInfo> createCloudletExecList(int numberOfCloudlets) {
         final List<CloudletExecutionInfo> cloudletExecList = new ArrayList<>();
         final Cloudlet cloudlet = createMockCloudlet(numberOfCloudlets);
@@ -47,14 +37,6 @@ public class ProcessorTest {
         EasyMock.expect(cloudlet.getFinishedLengthSoFar()).andReturn(0L).times(numberOfCloudlets);
         EasyMock.replay(cloudlet);
         return cloudlet;
-    }
-
-
-    @Test
-    public void testFromMips_EmptyCloudletExecList() {
-        final List<Double> mipsList = createMipsList(1);
-        final Processor result = Processor.fromMipsList(Vm.NULL, mipsList);
-        assertTrue("The processor cloudlet exec list should be empty", result.getCloudletExecList().isEmpty());
     }
 
     private List<Double> createMipsList(int numberOfPes) {
@@ -84,15 +66,6 @@ public class ProcessorTest {
     }
 
     @Test
-    public void testGetAvailableMipsByPe() {
-        final List<Double> mipsList = createMipsList(NUMBER_OF_PES);
-        final List<CloudletExecutionInfo> cloudletExecList = createCloudletExecList(NUMBER_OF_PES*2);
-        final Processor instance = Processor.fromMipsList(Vm.NULL, mipsList, cloudletExecList);
-        final double expResult = (PE_MIPS*NUMBER_OF_PES) / cloudletExecList.size();
-        assertEquals(expResult, instance.getAvailableMipsByPe(), 0.0);
-    }
-
-    @Test
     public void testGetNumberOfPes_FromDefaultConstructor() {
         final Processor instance = createDefaultProcessor();
         final int expResult = NUMBER_OF_PES;
@@ -115,21 +88,4 @@ public class ProcessorTest {
         assertEquals(expResult, instance.getMips(), 0.0);
     }
 
-    @Test
-    public void testGetCloudletExecList() {
-        final List<CloudletExecutionInfo> cloudletExecList = createCloudletExecList(2);
-        final List<Double> mipsList = createMipsList(NUMBER_OF_PES);
-        final Processor instance = Processor.fromMipsList(Vm.NULL, mipsList, cloudletExecList);
-        final Collection<CloudletExecutionInfo> result = instance.getCloudletExecList();
-        assertEquals("The number of cloudlets in the exec list is not as expected",
-                cloudletExecList.size(), result.size());
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGetCloudletExecList_ReadOnlyList() {
-        final List<CloudletExecutionInfo> cloudletExecList = createCloudletExecList(2);
-        final List<Double> mipsList = createMipsList(NUMBER_OF_PES);
-        final Processor instance = Processor.fromMipsList(Vm.NULL, mipsList, cloudletExecList);
-        instance.getCloudletExecList().add(null);
-    }
 }

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/resources/RamTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/resources/RamTest.java
@@ -59,31 +59,24 @@ public class RamTest {
         assertEquals(CAPACITY, instance.getCapacity());
 
         //reduce the capacity
-        long newCapacity = HALF_CAPACITY;
-        assertTrue(instance.setCapacity(newCapacity));
+        assertTrue(instance.setCapacity(HALF_CAPACITY));
+
+        assertTrue(instance.setCapacity(0));
 
         //try an invalid capacity
-        newCapacity = -1;
-        assertFalse(instance.setCapacity(newCapacity));
-
-        //try an invalid capacity
-        newCapacity = 0;
-        assertFalse(instance.setCapacity(newCapacity));
+        assertFalse(instance.setCapacity(-1));
 
         //restore the original capacity
-        newCapacity = CAPACITY;
-        assertTrue(instance.setCapacity(newCapacity));
+        assertTrue(instance.setCapacity(CAPACITY));
 
         //allocate resource and try to reduce the capacity below to the amount allocated
         final long allocated = HALF_CAPACITY;
         instance.allocateResource(allocated);
         assertEquals(allocated, instance.getAllocatedResource());
-        newCapacity = QUARTER_CAPACITY;
-        assertFalse(instance.setCapacity(newCapacity));
+        assertFalse(instance.setCapacity(QUARTER_CAPACITY));
 
         //try to increase the resource capacity
-        newCapacity = DOUBLE_CAPACITY;
-        assertTrue(instance.setCapacity(newCapacity));
+        assertTrue(instance.setCapacity(DOUBLE_CAPACITY));
     }
 
     @Test

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerSpaceSharedTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerSpaceSharedTest.java
@@ -346,18 +346,6 @@ public class CloudletSchedulerSpaceSharedTest {
         assertEquals(expResult, result);
     }
 
-    @Test
-    public void testGetTotalCurrentAvailableMipsForCloudlet() {
-        final CloudletExecutionInfo rcl = new CloudletExecutionInfo(Cloudlet.NULL);
-        final int schedulerPes = 2;
-        final List<Double> mipsShare =
-                CloudletSchedulerUtil.createMipsList(schedulerPes, SCHEDULER_MIPS);
-        final CloudletSchedulerSpaceShared instance = new CloudletSchedulerSpaceShared();
-        final double expResult = SCHEDULER_MIPS;
-        final double result = instance.getTotalCurrentAvailableMipsForCloudlet(rcl, mipsShare);
-        assertEquals(expResult, result, 0.0);
-    }
-
     @Test @Ignore("See the todo inside the tested method")
     public void testGetTotalCurrentAllocatedMipsForCloudlet() {
         final CloudletExecutionInfo rcl = new CloudletExecutionInfo(Cloudlet.NULL);

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerTest.java
@@ -28,7 +28,6 @@ public class CloudletSchedulerTest {
         assertEquals(0, instance.getCurrentRequestedRamPercentUtilization(), 0);
         assertEquals(0, instance.getPreviousTime(), 0);
         assertEquals(0, instance.getAllocatedMipsForCloudlet(null, 0), 0);
-        assertEquals(0, instance.getTotalCurrentAvailableMipsForCloudlet(null, null), 0);
         assertEquals(0, instance.getRequestedMipsForCloudlet(null, 0), 0);
         assertEquals(0, instance.getRequestedCpuPercentUtilization(0), 0);
         assertFalse(instance.hasFinishedCloudlets());

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerTimeSharedTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerTimeSharedTest.java
@@ -132,22 +132,6 @@ public class CloudletSchedulerTimeSharedTest {
         assertTrue(instance.isThereEnoughFreePesForCloudlet(new CloudletExecutionInfo(cloudlet0)));
     }
 
-    @Test
-    public void testGetTotalCurrentAvailableMipsForCloudlet_OneCloudlet() {
-        final long mips = 1000;
-        final int cloudletPes = 2;
-        final int schedulerPes = 4;
-        final CloudletExecutionInfo cloudlet =
-                new CloudletExecutionInfo(
-                        CloudletSimpleTest.createCloudlet0(mips, cloudletPes));
-        final CloudletSchedulerTimeShared instance =
-                createCloudletSchedulerWithMipsList(schedulerPes, mips);
-        final List<Double> mipsList = instance.getCurrentMipsShare();
-
-        final double result = instance.getTotalCurrentAvailableMipsForCloudlet(cloudlet, mipsList);
-        assertEquals((double) mips, result, 0.0);
-    }
-
     @Test @Ignore("The test is being ignored because the tested method in fact is always returning zero. It doesn't have an actual implementation.")
     public void testGetTotalCurrentAllocatedMipsForCloudlet() {
         final CloudletExecutionInfo rcl = new CloudletExecutionInfo(Cloudlet.NULL);


### PR DESCRIPTION
VM Cloner Function used to clone a VM when one is destroyed due to a Host failure is now associated
to the broker not to each VM to be cloned. 

For example, if you have 3 VMs, a new VM will be cloned only when all VMs belonging to that broker are destroyed. This way, you have to set the VM cloner Function just once for the broker.