### PR TITLE
Fix Bug: Power of a Idle Host is NOT 0

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelCubic.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelCubic.java
@@ -53,9 +53,6 @@ public class PowerModelCubic extends PowerModelAbstract {
 
 	@Override
 	protected double getPowerInternal(double utilization) throws IllegalArgumentException {
-		if (utilization == 0) {
-			return 0;
-		}
 		return getStaticPower() + getConstant() * Math.pow(utilization * 100, 3);
 	}
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelLinear.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelLinear.java
@@ -58,9 +58,6 @@ public class PowerModelLinear  extends PowerModelAbstract {
 
 	@Override
 	protected double getPowerInternal(final double utilization) throws IllegalArgumentException {
-		if (utilization == 0) {
-			return 0;
-		}
 		return getStaticPower() + getConstant() * utilization * 100;
 	}
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSqrt.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSqrt.java
@@ -51,9 +51,6 @@ public class PowerModelSqrt extends PowerModelAbstract {
 
 	@Override
 	protected double getPowerInternal(double utilization) throws IllegalArgumentException {
-		if (utilization == 0) {
-			return 0;
-		}
 		return getStaticPower() + getConstant() * Math.sqrt(utilization * 100);
 	}
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSquare.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSquare.java
@@ -57,9 +57,6 @@ public class PowerModelSquare extends PowerModelAbstract {
 
     @Override
     protected double getPowerInternal(double utilization) throws IllegalArgumentException {
-        if (utilization == 0) {
-            return 0;
-        }
         return getStaticPower() + getConstant() * Math.pow(utilization * 100, 2);
     }
 


### PR DESCRIPTION
check this:
In Not Spec Power Model:
When a host is idle(still active), its cpu capacity is 0, and its power should be `MAX_POWER * STATIC_POWER_PERCENT` .
However, when we use `host.getPowerSupply().getPowerModel().getPower(0)`, the return value is 0, not `MAX_POWER * STATIC_POWER_PERCENT` .

The **if condition** in the `#getPowerInternal`  seems to check if the host is active, but this check already included in the `#getPower`. So whenever the `#getPowerInternal` is used, the host is always active.

Hope this works!

