### PR TITLE
Improves docs and adds Vm.getTotalCpuMipsUsage()

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/migration/MigrationExample2_PowerUsage.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/migration/MigrationExample2_PowerUsage.java
@@ -268,17 +268,15 @@ public final class MigrationExample2_PowerUsage {
     }
 
     public void createAndSubmitCloudlets(DatacenterBroker broker) {
-        double initialCloudletCpuUtilizationPercentage = CLOUDLET_INITIAL_CPU_PERCENTAGE;
         final List<Cloudlet> list = new ArrayList<>(VMS -1);
         Cloudlet cloudlet = Cloudlet.NULL;
-        int id = 0;
-        UtilizationModelDynamic um = createCpuUtilizationModel(initialCloudletCpuUtilizationPercentage, 1);
+        UtilizationModelDynamic um = createCpuUtilizationModel(CLOUDLET_INITIAL_CPU_PERCENTAGE, 1);
         for(Vm vm: vmList){
             cloudlet = createCloudlet(vm, broker, um);
             list.add(cloudlet);
         }
 
-        //Changes the CPU usage of the last cloudlet to increase dynamically
+        //Changes the CPU usage of the last cloudlet to start at a lower value and increase dynamically up to 100%
         cloudlet.setUtilizationModelCpu(createCpuUtilizationModel(0.2, 1));
 
         broker.submitCloudletList(list);
@@ -380,8 +378,8 @@ public final class MigrationExample2_PowerUsage {
      * Increments the CPU resource utilization, that is defined in percentage values.
      * @return the new resource utilization after the increment
      */
-    private double getCpuUsageIncrement(UtilizationModelDynamic um){
-        return  um.getUtilization() + um.getTimeSpan()* CLOUDLET_CPU_INCREMENT_PER_SECOND;
+    private double getCpuUsageIncrement(final UtilizationModelDynamic um){
+        return  um.getUtilization() + um.getTimeSpan()*CLOUDLET_CPU_INCREMENT_PER_SECOND;
     }
 
     /**

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigration.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigration.java
@@ -39,8 +39,8 @@ public interface VmAllocationPolicyMigration extends VmAllocationPolicy {
      * Gets a <b>read-only</b> map of metric history.
      *
      * @TODO the map stores different data. Sometimes it stores the upper
-     * threshold, other it stores utilization threshold or predicted
-     * utilization, that is very confusing.
+     * threshold, other times it stores utilization threshold or predicted
+     * utilization. That is very confusing.
      *
      * @return the metric history
      */
@@ -55,7 +55,8 @@ public interface VmAllocationPolicyMigration extends VmAllocationPolicy {
     Map<Host, List<Double>> getTimeHistory();
 
     /**
-     * Checks if host is over utilized.
+     * Checks if host is over utilized, according the the
+     * conditions defined by the Allocation Policy.
      *
      * @param host the host to check
      * @return true, if the host is over utilized; false otherwise

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationBestFitStaticThreshold.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationBestFitStaticThreshold.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
  * detect host {@link #getUnderUtilizationThreshold() under} and
  * {@link #getOverUtilizationThreshold(Host)} over} utilization.
  *
- * <p>It's a <b>Worst Fit policy</b> which selects the Host having the least used amount of CPU
+ * <p>It's a <b>Best Fit policy</b> which selects the Host having the most used amount of CPU
  * MIPS to place a given VM, <b>disregarding energy consumption</b>.</p>
  *
  * @author Anton Beloglazov
@@ -70,7 +70,7 @@ public class VmAllocationPolicyMigrationBestFitStaticThreshold extends VmAllocat
      */
     @Override
     protected Optional<Host> findHostForVmInternal(final Vm vm, final Stream<Host> hostStream) {
-        /*It's ignoring the super class to intentionally avoid the additional filtering performed there
+        /*It's ignoring the super class intentionally to avoid the additional filtering performed there
         * and to apply a different method to select the Host to place the VM.*/
         return hostStream.max(Comparator.comparingDouble(Host::getUtilizationOfCpuMips));
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationStaticThreshold.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationStaticThreshold.java
@@ -90,7 +90,7 @@ public class VmAllocationPolicyMigrationStaticThreshold extends VmAllocationPoli
      * when creating an instance of the class.
      *
      * <p>
-     * <b>This method always return the same over utilization threshold for any
+     * <b>This implementation always returns the same over utilization threshold for any
      * given host</b></p>
      *
      * @param host {@inheritDoc}

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/PeProvisioner.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/PeProvisioner.java
@@ -4,8 +4,8 @@ import org.cloudbus.cloudsim.resources.Pe;
 import org.cloudbus.cloudsim.vms.Vm;
 
 /**
- * A class that represents the provisioning policy
- * used by a host to allocate its PEs to virtual machines inside it.
+ * An interface that represents the provisioning policy
+ * used by a host to provide virtual PEs to its virtual machines.
  * It gets a physical PE and manage it in order to provide this PE as virtual PEs for VMs.
  * In that way, a given PE might be shared among different VMs.
  *
@@ -35,9 +35,6 @@ public interface PeProvisioner extends ResourceProvisioner {
      * @param vm the virtual machine for which the new virtual PE is being allocated
      * @param mipsCapacity the MIPS to be allocated to the virtual PE of the given VM
      * @return $true if the virtual PE could be allocated; $false otherwise
-     *
-     * @pre $none
-     * @post $none
      */
     @Override
     boolean allocateResourceForVm(Vm vm, long mipsCapacity);
@@ -47,9 +44,6 @@ public interface PeProvisioner extends ResourceProvisioner {
      *
      * @param vm the virtual machine to get the allocated virtual Pe MIPS
      * @return the allocated virtual Pe MIPS
-     *
-     * @pre $none
-     * @post $none
      */
     @Override
     long getAllocatedResourceForVm(Vm vm);
@@ -58,18 +52,12 @@ public interface PeProvisioner extends ResourceProvisioner {
      * Releases the virtual Pe allocated to a given VM.
      *
      * @param vm the vm to release the virtual Pe
-     *
-     * @pre $none
-     * @post none
      */
     @Override
     boolean deallocateResourceForVm(Vm vm);
 
     /**
      * Releases all virtual PEs allocated to all VMs.
-     *
-     * @pre $none
-     * @post none
      */
     @Override
     void deallocateResourceForAllVms();
@@ -88,5 +76,4 @@ public interface PeProvisioner extends ResourceProvisioner {
      * @return the utilization percentage from 0 to 1
      */
     double getUtilization();
-
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/PeProvisionerSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/PeProvisionerSimple.java
@@ -9,14 +9,18 @@ package org.cloudbus.cloudsim.provisioners;
 
 import java.util.*;
 
+import org.cloudbus.cloudsim.hosts.Host;
 import org.cloudbus.cloudsim.resources.Pe;
 
 /**
- * A {@link PeProvisioner} that uses a best-effort policy to allocate virtual PEs to VMs from a physical PE:
- * if there is available MIPS on the physical PE, it allocates to a virtual PE; otherwise, it fails. Each
- * host's PE has to have its own instance of a PeProvisioner.
+ * A best-effort {@link PeProvisioner} policy used by a {@link Host} to provide virtual PEs to VMs from its physical PEs:
+ * <ul>
+ *   <li>if there is available MIPS on the physical PE, it allocates to a virtual PE;</li>
+ *   <li>otherwise, it fails.</li>
+ * </ul>
  *
- * <p>Each host's PE must have its own instance of a PeProvisioner. When extending this class,
+ * <p>
+ * Each host's PE must have its own instance of a PeProvisioner. When extending this class,
  * care must be taken to guarantee that the field availableMips will always
  * contain the amount of free MIPS available for future allocations.
  * </p>
@@ -30,9 +34,6 @@ public class PeProvisionerSimple extends ResourceProvisionerSimple implements Pe
     /**
      * Instantiates a new PeProvisionerSimple that the {@link Pe} it will manage will be set
      * just at Pe instantiation.
-     *
-     * @pre $none
-     * @post $none
      */
     public PeProvisionerSimple() {
         super(Pe.NULL);
@@ -42,8 +43,6 @@ public class PeProvisionerSimple extends ResourceProvisionerSimple implements Pe
      * Instantiates a new PeProvisionerSimple for a given {@link Pe}.
      *
      * @param pe
-     * @pre $none
-     * @post $none
      */
     public PeProvisionerSimple(Pe pe){
         super(pe);

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/ResourceProvisioner.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/ResourceProvisioner.java
@@ -14,15 +14,25 @@ import org.cloudbus.cloudsim.vms.Vm;
 
 /**
  * An interface that represents the provisioning policy used by a {@link Host}
- * to allocate a given physical resource to {@link Vm}s inside it.
+ * to provide a given physical resource to its {@link Vm}s.
  *
- * Each host has to have its own instance of a ResourceProvisioner for each
+ * Each host must have its own instance of a ResourceProvisioner for each
  * {@link Resource} it owns, such as {@link Ram}, {@link Bandwidth} (BW) and {@link Pe} (CPU).
  *
  * @author Rodrigo N. Calheiros
  * @author Anton Beloglazov
  * @author Manoel Campos da Silva Filho
  * @since CloudSim Plus 1.0
+ * @todo There is a lot of confusion between Resource Allocation and Resource Provisioning.
+ *       This article makes it clear: https://www.researchgate.net/post/what_is_the_difference_between_resource_allocation_and_resource_provisioning.
+ *       Allocation is reservation, while Provisioning is actual usage of some part of the allocated resource.
+ *       When a VM is created, the Host allocates resources, but the Host.allocateResourcesForVm
+ *       uses ResourceProvisioners for that. More confusing yet, it calls vmScheduler.allocatePesForVm at the end.
+ *       The terms allocation and provisioning sometimes are used in the same place.
+ *       The Host.allocateResourcesForVm method has the word "allocate" in its name,
+ *       while internally it uses ResourceProvisioners (quite confusing).
+ *       VmScheduler is using the term "allocation", but since it's accountable for running a VM,
+ *       it should perform resource provisioning (request the actual amount of the allocated resource to be used in that moment).
  */
 public interface ResourceProvisioner {
     /**
@@ -32,7 +42,7 @@ public interface ResourceProvisioner {
     ResourceProvisioner NULL = new ResourceProvisionerNull();
 
     /**
-     * Allocates an amount of the physical resource for a given VM, changing the current capacity
+     * Allocates an amount of the physical resource for a VM, changing the current capacity
      * of the virtual resource to the given amount.
      *
      * @param vm the virtual machine for which the resource is being allocated
@@ -42,14 +52,11 @@ public interface ResourceProvisioner {
      * it changes the VM allocated resource to that specific amount
      *
      * @return $true if the resource could be allocated; $false otherwise
-     *
-     * @pre $none
-     * @post $none
      */
     boolean allocateResourceForVm(Vm vm, long newTotalVmResourceCapacity);
 
     /**
-     * Allocates an amount of the physical resource for a given VM, changing the current capacity
+     * Allocates an amount of the physical resource for a VM, changing the current capacity
      * of the virtual resource to the given amount.
      *
      * <p>This method is just a shorthand to avoid explicitly converting
@@ -89,17 +96,11 @@ public interface ResourceProvisioner {
      * @param vm the vm
      * @return true if the resource was deallocated; false if the related resource
      * has never been allocated to the given VM.
-     *
-     * @pre $none
-     * @post none
      */
     boolean deallocateResourceForVm(Vm vm);
 
     /**
      * Releases all the allocated amount of the resource used by all VMs.
-     *
-     * @pre $none
-     * @post none
      */
     void deallocateResourceForAllVms();
 
@@ -140,7 +141,7 @@ public interface ResourceProvisioner {
      * @return the amount of free available physical resource
      */
     long getAvailableResource();
-    
+
     /**
      * Checks if the resource the provisioner manages is allocated to a given Vm.
      * @param vm the VM to check if the resource is allocated to

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/ResourceProvisionerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/ResourceProvisionerAbstract.java
@@ -12,12 +12,13 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import org.cloudbus.cloudsim.hosts.Host;
 import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudbus.cloudsim.resources.ResourceManageable;
 
 /**
- * An abstract class that implements the basic features of a provisioning policy used by a host
- * to allocate a given resource to virtual machines inside it.
+ * An abstract class that implements the basic features of a provisioning policy used by a {@link Host}
+ * to provide a given resource to its virtual machines.
  *
  * @see ResourceProvisioner
  * @author Rodrigo N. Calheiros
@@ -42,8 +43,6 @@ public abstract class ResourceProvisionerAbstract implements ResourceProvisioner
     /**
      * Creates a new ResourceManageable Provisioner for which the {@link #getResource() resource}
      * must be set further.
-     *
-     * @post $none
      */
     protected ResourceProvisionerAbstract() {
         this(ResourceManageable.NULL);
@@ -53,7 +52,6 @@ public abstract class ResourceProvisionerAbstract implements ResourceProvisioner
      * Creates a new ResourceManageable Provisioner.
      *
      * @param resource The resource to be managed by the provisioner
-     * @post $none
      */
     public ResourceProvisionerAbstract(final ResourceManageable resource) {
         this.setResource(resource);
@@ -62,13 +60,13 @@ public abstract class ResourceProvisionerAbstract implements ResourceProvisioner
 
     @Override
     public long getAllocatedResourceForVm(Vm vm) {
-        return getResourceAllocationMap().getOrDefault(vm, 0L);
+        return resourceAllocationMap.getOrDefault(vm, 0L);
     }
 
     @Override
     public void deallocateResourceForAllVms() {
-        for(final Vm vm: getResourceAllocationMap().keySet()){
-            deallocateResourceForVmSettingAllocationMapEntryToZero(vm);
+        for(final Vm vm: resourceAllocationMap.keySet()){
+            deallocateResourceForVmAndSetAllocationMapEntryToZero(vm);
         }
         getResourceAllocationMap().clear();
     }
@@ -80,7 +78,7 @@ public abstract class ResourceProvisionerAbstract implements ResourceProvisioner
      * @param vm the VM to deallocate resource
      * @return the amount of allocated VM resource or zero if VM is not found
      */
-    protected abstract long deallocateResourceForVmSettingAllocationMapEntryToZero(Vm vm);
+    protected abstract long deallocateResourceForVmAndSetAllocationMapEntryToZero(Vm vm);
 
     @Override
     public ResourceManageable getResource() {
@@ -130,5 +128,4 @@ public abstract class ResourceProvisionerAbstract implements ResourceProvisioner
     public boolean isResourceAllocatedToVm(Vm vm) {
         return resourceAllocationMap.keySet().contains(vm);
     }
-
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/ResourceProvisionerSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/provisioners/ResourceProvisionerSimple.java
@@ -8,6 +8,7 @@
 
 package org.cloudbus.cloudsim.provisioners;
 
+import org.cloudbus.cloudsim.hosts.Host;
 import org.cloudbus.cloudsim.resources.Pe;
 import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudbus.cloudsim.resources.ResourceManageable;
@@ -15,10 +16,11 @@ import org.cloudbus.cloudsim.resources.ResourceManageable;
 import java.util.Objects;
 
 /**
- * ResourceProvisionerSimple is a {@link ResourceProvisioner} implementation
- * which uses a best-effort policy to allocate a resource to VMs:
- * if there is available amount of the resource on the host, it allocates;
- * otherwise, it fails.
+ * A best-effort {@link ResourceProvisioner} policy used by a {@link Host} to provide a resource to VMs:
+ * <ul>
+ *  <li>if there is available amount of the resource on the host, it provides;</li>
+ *  <li>otherwise, it fails.</li>
+ * </ul>
  *
  * @author Rodrigo N. Calheiros
  * @author Anton Beloglazov
@@ -27,10 +29,9 @@ import java.util.Objects;
  */
 public class ResourceProvisionerSimple extends ResourceProvisionerAbstract {
     /**
-     * Creates a new ResourceProvisionerSimple which the {@link ResourceManageable} it will manage
-     * have to be set further.
+     * Creates a new ResourceProvisionerSimple which the {@link ResourceManageable}
+     * it will manage have to be set further.
      *
-     * @post $none
      * @see #setResource(ResourceManageable)
      */
     public ResourceProvisionerSimple() {
@@ -41,7 +42,6 @@ public class ResourceProvisionerSimple extends ResourceProvisionerAbstract {
      * Creates a new ResourceProvisionerSimple.
      *
      * @param resource the resource to be managed by the provisioner
-     * @post $none
      */
     protected ResourceProvisionerSimple(final ResourceManageable resource) {
         super(resource);
@@ -84,13 +84,13 @@ public class ResourceProvisionerSimple extends ResourceProvisionerAbstract {
 
     @Override
     public boolean deallocateResourceForVm(final Vm vm) {
-        final long amountFreed = deallocateResourceForVmSettingAllocationMapEntryToZero(vm);
+        final long amountFreed = deallocateResourceForVmAndSetAllocationMapEntryToZero(vm);
         getResourceAllocationMap().remove(vm);
         return amountFreed > 0;
     }
 
     @Override
-    protected long deallocateResourceForVmSettingAllocationMapEntryToZero(final Vm vm) {
+    protected long deallocateResourceForVmAndSetAllocationMapEntryToZero(final Vm vm) {
         if (getResourceAllocationMap().containsKey(vm)) {
             final long vmAllocatedResource = getResourceAllocationMap().get(vm);
             getResourceAllocationMap().put(vm, 0L);
@@ -111,5 +111,4 @@ public class ResourceProvisionerSimple extends ResourceProvisionerAbstract {
         final long allocationDifference = newVmTotalAllocatedResource - currentAllocatedResource;
         return getResource().getAvailableResource() >=  allocationDifference;
     }
-
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/utilizationmodels/UtilizationModelDynamic.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/utilizationmodels/UtilizationModelDynamic.java
@@ -134,6 +134,7 @@ public class UtilizationModelDynamic extends UtilizationModelAbstract {
         this.currentUtilizationTime = source.currentUtilizationTime;
         this.previousUtilizationTime = source.previousUtilizationTime;
         this.maxResourceUtilization = source.maxResourceUtilization;
+        this.setSimulation(source.getSimulation());
 
         /** The copy constructor doesn't copy the utilizationUpdateFunction because
          * when this constructor is used, it sets the copy

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -150,7 +150,7 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
     /**
      * Changes the allocation of a given resource for a VM.
      * The old allocated amount will be changed to the new given amount.
-     *  @param resourceClass the class of the resource to change the allocation
+     * @param resourceClass the class of the resource to change the allocation
      * @param newTotalResourceAmount the new amount to change the current allocation to*/
     void allocateResource(Class<? extends ResourceManageable> resourceClass, long newTotalResourceAmount);
 
@@ -309,6 +309,15 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
     double getCpuPercentUsage();
 
     /**
+     * Gets the current total CPU MIPS utilization of all PEs from all cloudlets running on this VM.
+     *
+     * @return total CPU utilization in MIPS
+     * @see #getCpuPercentUsage(double)
+     *
+     */
+    double getTotalCpuMipsUsage();
+
+    /**
      * Gets the total CPU MIPS utilization of all PEs from all cloudlets running on this VM at the
      * given time.
      *
@@ -323,8 +332,6 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
      * Gets the Virtual Machine Monitor (VMM) that manages the VM.
      *
      * @return VMM
-     * @pre $none
-     * @post $none
      */
     String getVmm();
 
@@ -380,8 +387,6 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
      * Sets the PM that hosts the VM.
      *
      * @param host Host to run the VM
-     * @pre host != $null
-     * @post $none
      */
     void setHost(Host host);
 
@@ -391,7 +396,6 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
      * @param ramCapacity new RAM capacity
      * @return
      * @pre ramCapacity > 0
-     * @post $none
      */
     Vm setRam(long ramCapacity);
 
@@ -401,8 +405,6 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
      * @param size new storage size
      * @return
      * @pre size > 0
-     * @post $none
-     *
      */
     Vm setSize(long size);
 
@@ -416,7 +418,6 @@ public interface Vm extends Machine, UniquelyIdentificable, Comparable<Vm>, Cust
      * (which is a relative delay from the current simulation time),
      * or {@link Double#MAX_VALUE} if there is no next Cloudlet to execute
      * @pre currentTime >= 0
-     * @post $none
      */
     double updateProcessing(double currentTime, List<Double> mipsShare);
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
@@ -112,6 +112,7 @@ final class VmNull implements Vm {
     @Override public double getCpuPercentUsage() {
         return 0;
     }
+    @Override public double getTotalCpuMipsUsage() { return 0; }
     @Override public double getTotalCpuMipsUsage(double time) {
         return 0.0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -238,6 +238,11 @@ public class VmSimple implements Vm {
     }
 
     @Override
+    public double getTotalCpuMipsUsage() {
+        return getTotalCpuMipsUsage(getSimulation().clock());
+    }
+
+    @Override
     public double getTotalCpuMipsUsage(final double time) {
         return getCpuPercentUsage(time) * getTotalMipsCapacity();
     }


### PR DESCRIPTION
- Updates MigrationExample1 documentation and refactors VmAllocationPolicyMigration.
- Updates ResourceProvisioner documentation.
- Adds getTotalCpuMipsUsage() to Vm to get the current total MIPS used across all virtual PEs.
