### PR TITLE
Closes #132

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/HarddriveStorage.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/HarddriveStorage.java
@@ -319,10 +319,10 @@ public class HarddriveStorage implements FileStorage {
      * @param fileSize the size of the transferred file (in MByte)
      * @return the transfer time in seconds
      */
-    private double getTransferTime(final int fileSize) {
+    protected double getTransferTime(final int fileSize) {
         double result = 0;
         if (fileSize > 0 && storage.getCapacity() != 0) {
-            result = (fileSize * maxTransferRate) / (double)storage.getCapacity();
+            result = (fileSize * getMaxTransferRate()) / (double)storage.getCapacity();
         }
 
         return result;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/SanStorage.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/SanStorage.java
@@ -63,7 +63,7 @@ public class SanStorage extends HarddriveStorage {
     @Override
     public double addReservedFile(final File file) {
         final double time = super.addReservedFile(file);
-        return time + getFileTransferTimePlusNetworkLatency(file);
+        return time + getTransferTime(file.getSize());
     }
 
     /**
@@ -87,19 +87,19 @@ public class SanStorage extends HarddriveStorage {
     public double addFile(final File file) {
         final double time = super.addFile(file);
         if(time > 0)
-            return time + getFileTransferTimePlusNetworkLatency(file);
+            return time + getTransferTime(file.getSize());
 
         return time;
     }
 
-    private double getFileTransferTimePlusNetworkLatency(final File file) {
-        return file.getSize()*getBandwidth() + getNetworkLatency();
+    protected double getTransferTime(final int fileSize) {
+        return fileSize*getMaxTransferRate() + getNetworkLatency();
     }
 
     @Override
     public double deleteFile(final File file) {
         final double time = super.deleteFile(file);
-        return time + getFileTransferTimePlusNetworkLatency(file);
+        return time + getTransferTime(file.getSize());
     }
 
     /**


### PR DESCRIPTION
This method got removed from the SanStorage class, and where it was
referenced the overrided getTransferTime from super class is used now
instead.

#### Still the logic of getTransferTime isn't right in both SanStorage and HarddriveStorage

#### Note: The removed method used to have a File parameter while the inherited getTransferTime use an integer (fileSize) as a parameter 
