### PR TITLE
Refactor FileStorage and file transfer time computation.

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/FileStorage.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/FileStorage.java
@@ -28,6 +28,8 @@ import java.util.List;
  * @author Manoel Campos da Silva Filho
  */
 public interface FileStorage extends Resource {
+    int FILE_NOT_FOUND = -1;
+
     /**
      *
      * @return the name of the storage device
@@ -123,7 +125,15 @@ public interface FileStorage extends Resource {
     /**
      * Gets the transfer time of a given file.
      *
-     * @param file the file to compute the transfer time where its size is defined in MByte
+     * @param fileName the name of the file to compute the transfer time (where its size is defined in MByte)
+     * @return the transfer time in seconds or {@link #FILE_NOT_FOUND} if the file was not found in this storage device
+     */
+    double getTransferTime(String fileName);
+
+    /**
+     * Gets the transfer time of a given file.
+     *
+     * @param file the file to compute the transfer time (where its size is defined in MByte)
      * @return the transfer time in seconds
      */
     double getTransferTime(File file);
@@ -207,4 +217,11 @@ public interface FileStorage extends Resource {
      * @return <tt>true</tt> if enough space available, <tt>false</tt> otherwise
     */
     boolean hasPotentialAvailableSpace(int fileSize);
+
+    /**
+     * Checks if the storage device has a specific file.
+     * @param fileName the name of the file to check if it's contained in this storage device.
+     * @return true if the storage device has the file, false otherwise.
+     */
+    boolean hasFile(String fileName);
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/HarddriveStorage.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/HarddriveStorage.java
@@ -176,6 +176,11 @@ public class HarddriveStorage implements FileStorage {
         return getDeletedFilesTotalSize() > fileSize;
     }
 
+    @Override
+    public boolean hasFile(final String fileName) {
+        return getFile(fileName) != null;
+    }
+
     private int getDeletedFilesTotalSize() {
         return fileList.stream().filter(File::isDeleted).mapToInt(File::getSize).sum();
     }
@@ -307,6 +312,16 @@ public class HarddriveStorage implements FileStorage {
         }
 
         return result;
+    }
+
+    @Override
+    public double getTransferTime(final String fileName) {
+        final File file = getFile(fileName);
+        if(file == null){
+            return FILE_NOT_FOUND;
+        }
+
+        return getTransferTime(file);
     }
 
     @Override


### PR DESCRIPTION
- Adds the `hasFile(String fileName)` method to the `FileStorage` class to check if a storage device has a specific file.
- Adds the `double getTransferTime(String fileName)` method to the `FileStorage` class to get the time to transfer a file from the device. If the file is not found, the method returns `FileStorage.FILE_NOT_FOUND`.
- Refactor `DatacenterSimple.predictFileTransferTime` to use the new `FileStorage` `getTransferTime(String fileName)` method, making just one call to get the file transfer time (moving the complexity of first trying to get the file to the `HarddriveStorage` class).