### PR TITLE
Closes #141

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/StorageAreaNetworkExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/StorageAreaNetworkExample1.java
@@ -146,7 +146,7 @@ import java.util.List;
             sanList.add(san);
         }
 
-        dc.setStorageList(sanList);
+        dc.getDatacenterStorage().setStorageList(sanList);
     }
 
     /**

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/Datacenter.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/Datacenter.java
@@ -13,6 +13,7 @@ import org.cloudbus.cloudsim.power.models.PowerModel;
 import org.cloudbus.cloudsim.vms.Vm;
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.core.SimEntity;
+import org.cloudbus.cloudsim.resources.DatacenterStorage;
 import org.cloudbus.cloudsim.resources.File;
 import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicy;
 import org.cloudbus.cloudsim.resources.FileStorage;
@@ -43,16 +44,6 @@ public interface Datacenter extends SimEntity, PowerAware {
      * @see #setBandwidthPercentForMigration(double)
      */
     double DEF_BANDWIDTH_PERCENT_FOR_MIGRATION = 0.5;
-
-    /**
-     * Adds a file into the resource's storage before the experiment starts. If
-     * the file is a master file, then it will be registered to the RC when the
-     * experiment begins.
-     *
-     * @param file a DataCloud file
-     * @return a tag number denoting whether this operation is a success or not
-     */
-    int addFile(File file);
 
     /**
      * Gets an <b>unmodifiable</b> host list.
@@ -148,19 +139,19 @@ public interface Datacenter extends SimEntity, PowerAware {
     DatacenterCharacteristics getCharacteristics();
 
     /**
-     * Gets a <b>read-only</b> list of storage devices of the Datacenter.
+     * Gets a <b>read-only</b> storage of the Datacenter.
      *
-     * @return the storage list
+     * @return the storage
      */
-    List<FileStorage> getStorageList();
+    DatacenterStorage getDatacenterStorage();
 
     /**
-     * Sets the list of storage devices of the Datacenter.
+     * Sets storage of the Datacenter.
      *
-     * @param storageList the new storage list
+     * @param datacenterStorage the new storage
      * @return
      */
-    Datacenter setStorageList(List<FileStorage> storageList);
+    void setDatacenterStorage(DatacenterStorage datacenterStorage);
 
     /**
      * Gets the percentage of the bandwidth allocated to a Host to
@@ -198,4 +189,5 @@ public interface Datacenter extends SimEntity, PowerAware {
      */
     @Override
     double getPower();
+
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/DatacenterNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/DatacenterNull.java
@@ -1,16 +1,16 @@
 package org.cloudbus.cloudsim.datacenters;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicy;
 import org.cloudbus.cloudsim.core.SimEntity;
 import org.cloudbus.cloudsim.core.Simulation;
 import org.cloudbus.cloudsim.core.events.SimEvent;
 import org.cloudbus.cloudsim.hosts.Host;
+import org.cloudbus.cloudsim.resources.DatacenterStorage;
 import org.cloudbus.cloudsim.resources.File;
-import org.cloudbus.cloudsim.resources.FileStorage;
 import org.cloudbus.cloudsim.vms.Vm;
-
-import java.util.Collections;
-import java.util.List;
 
 /**
  * A class that implements the Null Object Design Pattern for
@@ -28,9 +28,6 @@ final class DatacenterNull implements Datacenter {
     }
     @Override public String getName() {
         return "";
-    }
-    @Override public int addFile(File file) {
-        return 0;
     }
     @Override public List<Host> getHostList() {
         return Collections.emptyList();
@@ -55,11 +52,10 @@ final class DatacenterNull implements Datacenter {
     @Override public DatacenterCharacteristics getCharacteristics() {
         return DatacenterCharacteristics.NULL;
     }
-    @Override public List<FileStorage> getStorageList() {
-        return Collections.emptyList();
+    @Override public DatacenterStorage getDatacenterStorage() {
+    	return new DatacenterStorage().setStorageList(Collections.emptyList());
     }
-    @Override public Datacenter setStorageList(List<FileStorage> storageList) {
-        return Datacenter.NULL;
+    @Override public void setDatacenterStorage(DatacenterStorage datacenterStorage) {
     }
     @Override public double getBandwidthPercentForMigration() { return 0; }
     @Override public void setBandwidthPercentForMigration(double bandwidthPercentForMigration) {/**/}

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/DatacenterSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/DatacenterSimple.java
@@ -6,27 +6,33 @@
  */
 package org.cloudbus.cloudsim.datacenters;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicy;
+import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.cloudlets.CloudletExecution;
-import org.cloudbus.cloudsim.core.events.SimEvent;
+import org.cloudbus.cloudsim.core.CloudSimEntity;
+import org.cloudbus.cloudsim.core.CloudSimTags;
+import org.cloudbus.cloudsim.core.Simulation;
 import org.cloudbus.cloudsim.core.events.PredicateType;
+import org.cloudbus.cloudsim.core.events.SimEvent;
+import org.cloudbus.cloudsim.hosts.Host;
 import org.cloudbus.cloudsim.network.IcmpPacket;
+import org.cloudbus.cloudsim.resources.DatacenterStorage;
+import org.cloudbus.cloudsim.resources.File;
+import org.cloudbus.cloudsim.resources.FileStorage;
+import org.cloudbus.cloudsim.schedulers.cloudlet.CloudletScheduler;
 import org.cloudbus.cloudsim.util.Conversion;
 import org.cloudbus.cloudsim.util.DataCloudTags;
-import org.cloudbus.cloudsim.hosts.Host;
 import org.cloudbus.cloudsim.util.Log;
 import org.cloudbus.cloudsim.vms.Vm;
-import org.cloudbus.cloudsim.cloudlets.Cloudlet;
-import org.cloudbus.cloudsim.core.*;
-import org.cloudbus.cloudsim.resources.File;
-import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicy;
-import org.cloudbus.cloudsim.schedulers.cloudlet.CloudletScheduler;
-
-import java.util.*;
-
-import org.cloudbus.cloudsim.resources.FileStorage;
 import org.cloudsimplus.autoscaling.VerticalVmScaling;
-
-import static java.util.stream.Collectors.toList;
 
 /**
  * Implements the basic features of a Virtualized Cloud Datacenter. It deals
@@ -65,11 +71,12 @@ public class DatacenterSimple extends CloudSimEntity implements Datacenter {
     /** @see #getLastProcessTime() */
     private double lastProcessTime;
 
-    /** @see #getStorageList() */
-    private List<FileStorage> storageList;
 
     /** @see #getSchedulingInterval() */
     private double schedulingInterval;
+
+    /** @see #getDatacenterStorage() */
+	private DatacenterStorage datacenterStorage;
 
     /**
      * Creates a Datacenter.
@@ -94,7 +101,8 @@ public class DatacenterSimple extends CloudSimEntity implements Datacenter {
 
         setLastProcessTime(0.0);
         setSchedulingInterval(0);
-        setStorageList(new ArrayList<>());
+        setDatacenterStorage(new DatacenterStorage());
+        getDatacenterStorage().setDatacenter(this);
 
         this.characteristics = new DatacenterCharacteristicsSimple(this);
         this.bandwidthPercentForMigration = DEF_BANDWIDTH_PERCENT_FOR_MIGRATION;
@@ -304,7 +312,7 @@ public class DatacenterSimple extends CloudSimEntity implements Datacenter {
      */
     private void submitCloudletToVm(final Cloudlet cl, final boolean ack) {
         // time to transfer cloudlet's files
-        final double fileTransferTime = predictFileTransferTime(cl.getRequiredFiles());
+        final double fileTransferTime = getDatacenterStorage().predictFileTransferTime(cl.getRequiredFiles());
 
         final CloudletScheduler scheduler = cl.getVm().getCloudletScheduler();
         final double estimatedFinishTime = scheduler.cloudletSubmit(cl, fileTransferTime);
@@ -545,40 +553,6 @@ public class DatacenterSimple extends CloudSimEntity implements Datacenter {
     }
 
     /**
-     * Predict the total time to transfer a list of files.
-     *
-     * @param requiredFiles the files to be transferred
-     * @return the total predicted time to transfer the files
-     */
-    protected double predictFileTransferTime(final List<String> requiredFiles) {
-        double totalTime = 0.0;
-
-        for (final String fileName: requiredFiles) {
-            totalTime += Math.max(timeToTransferFileFromStorage(fileName), 0);
-        }
-
-        return totalTime;
-    }
-
-    /**
-     * Try to get a file from a storage device in the {@link #storageList}
-     * and computes the time to transfer it from that device.
-     *
-     * @param fileName the name of the file to try finding and get the transfer time
-     * @return the time to transfer the file or {@link FileStorage#FILE_NOT_FOUND} if not found.
-     */
-    private double timeToTransferFileFromStorage(final String fileName) {
-        for (final FileStorage storage: getStorageList()) {
-            final double transferTime = storage.getTransferTime(fileName);
-            if (transferTime != FileStorage.FILE_NOT_FOUND) {
-                return transferTime;
-            }
-        }
-
-        return FileStorage.FILE_NOT_FOUND;
-    }
-
-    /**
      * Updates the processing of all Hosts, meaning
      * it makes the processing of VMs running inside such hosts to be updated.
      * Finally, the processing of Cloudlets running inside such VMs is updated too.
@@ -763,54 +737,6 @@ public class DatacenterSimple extends CloudSimEntity implements Datacenter {
     }
 
     @Override
-    public int addFile(final File file) {
-        Objects.requireNonNull(file);
-
-        if (contains(file.getName())) {
-            return DataCloudTags.FILE_ADD_ERROR_EXIST_READ_ONLY;
-        }
-
-        // check storage space first
-        if (getStorageList().isEmpty()) {
-            return DataCloudTags.FILE_ADD_ERROR_STORAGE_FULL;
-        }
-
-        for (final FileStorage storage : getStorageList()) {
-            if (storage.isResourceAmountAvailable((long) file.getSize())) {
-                storage.addFile(file);
-                return DataCloudTags.FILE_ADD_SUCCESSFUL;
-            }
-        }
-
-        return DataCloudTags.FILE_ADD_ERROR_STORAGE_FULL;
-    }
-
-    /**
-     * Checks whether the Datacenter has the given file.
-     *
-     * @param file a file to be searched
-     * @return <tt>true</tt> if successful, <tt>false</tt> otherwise
-     */
-    protected boolean contains(final File file) {
-        Objects.requireNonNull(file);
-        return contains(file.getName());
-    }
-
-    /**
-     * Checks whether the Datacenter has the given file.
-     *
-     * @param fileName a file name to be searched
-     * @return <tt>true</tt> if successful, <tt>false</tt> otherwise
-     */
-    protected boolean contains(final String fileName) {
-        if (fileName == null || fileName.trim().isEmpty()) {
-            return false;
-        }
-
-        return storageList.stream().anyMatch(storage -> storage.contains(fileName));
-    }
-
-    @Override
     public void shutdownEntity() {
         super.shutdownEntity();
         Log.printFormattedLine("%.2f: %s is shutting down...", getSimulation().clock(), getName());
@@ -872,33 +798,19 @@ public class DatacenterSimple extends CloudSimEntity implements Datacenter {
     }
 
     @Override
-    public List<FileStorage> getStorageList() {
-        return Collections.unmodifiableList(storageList);
+    public DatacenterStorage getDatacenterStorage() {
+        return this.datacenterStorage;
     }
 
     /**
-     * Sets the list of storage devices of the Datacenter.
+     * Sets the storage of the Datacenter.
      *
-     * @param storageList the new storage list
+     * @param datacenterStorage the new storage object
      * @return
      */
     @Override
-    public final Datacenter setStorageList(final List<FileStorage> storageList) {
-        Objects.requireNonNull(storageList);
-        this.storageList = storageList;
-        setAllFilesOfAllStoragesToThisDatacenter();
-
-        return this;
-    }
-
-    /**
-     * Assigns all files of all storage devices to this Datacenter.
-     */
-    private void setAllFilesOfAllStoragesToThisDatacenter() {
-        storageList.stream()
-                .map(FileStorage::getFileList)
-                .flatMap(List::stream)
-                .forEach(file -> file.setDatacenter(this));
+    public void setDatacenterStorage(DatacenterStorage datacenterStorage) {
+        this.datacenterStorage = datacenterStorage;
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/DatacenterStorage.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/resources/DatacenterStorage.java
@@ -1,0 +1,139 @@
+package org.cloudbus.cloudsim.resources;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.cloudbus.cloudsim.datacenters.Datacenter;
+import org.cloudbus.cloudsim.util.DataCloudTags;
+
+public class DatacenterStorage {
+	
+	/** @see #getStorageList() */
+    private List<FileStorage> storageList;
+    
+    /** @see #getDatacenter() */
+	private Datacenter datacenter;
+
+	public DatacenterStorage(){
+    	this.storageList = new ArrayList<>();
+    }
+    
+    /**
+     * Checks whether the storageList has the given file.
+     *
+     * @param file a file to be searched
+     * @return <tt>true</tt> if successful, <tt>false</tt> otherwise
+     */
+    public boolean contains(final File file) {
+        Objects.requireNonNull(file);
+        return contains(file.getName());
+    }
+
+    /**
+     * Checks whether the storageList has the given file.
+     *
+     * @param fileName a file name to be searched
+     * @return <tt>true</tt> if successful, <tt>false</tt> otherwise
+     */
+    public boolean contains(final String fileName) {
+        if (fileName == null || fileName.trim().isEmpty()) {
+            return false;
+        }
+
+        return storageList.stream().anyMatch(storage -> storage.contains(fileName));
+    }
+     
+    public List<FileStorage> getStorageList() {
+        return Collections.unmodifiableList(storageList);
+    }
+
+    /**
+     * Sets the list of storage devices of the Datacenter.
+     *
+     * @param storageList the new storage list
+     * @return
+     */
+    public final DatacenterStorage setStorageList(final List<FileStorage> storageList) {
+        Objects.requireNonNull(storageList);
+        this.storageList = storageList;
+        setAllFilesOfAllStoragesToThisDatacenter();
+
+        return this;
+    }
+
+    /**
+     * Assigns all files of all storage devices to this Datacenter.
+     */
+    public void setAllFilesOfAllStoragesToThisDatacenter() {
+        storageList.stream()
+                .map(FileStorage::getFileList)
+                .flatMap(List::stream)
+                .forEach(file -> file.setDatacenter(this.getDatacenter()));
+    }
+
+    public Datacenter getDatacenter() {
+		return datacenter;
+	}
+
+	public void setDatacenter(Datacenter datacenter) {
+		this.datacenter = datacenter;
+	}
+	
+	/**
+     * Predict the total time to transfer a list of files.
+     *
+     * @param requiredFiles the files to be transferred
+     * @return the total predicted time to transfer the files
+     */
+    public double predictFileTransferTime(final List<String> requiredFiles) {
+        double totalTime = 0.0;
+
+        for (final String fileName: requiredFiles) {
+            totalTime += Math.max(timeToTransferFileFromStorage(fileName), 0);
+        }
+
+        return totalTime;
+    }
+
+    /**
+     * Try to get a file from a storage device in the {@link #storageList}
+     * and computes the time to transfer it from that device.
+     *
+     * @param fileName the name of the file to try finding and get the transfer time
+     * @return the time to transfer the file or {@link FileStorage#FILE_NOT_FOUND} if not found.
+     */
+    private double timeToTransferFileFromStorage(final String fileName) {
+        for (final FileStorage storage: getStorageList()) {
+            final double transferTime = storage.getTransferTime(fileName);
+            if (transferTime != FileStorage.FILE_NOT_FOUND) {
+                return transferTime;
+            }
+        }
+
+        return FileStorage.FILE_NOT_FOUND;
+    }
+
+    public int addFile(final File file) {
+        Objects.requireNonNull(file);
+
+        if (contains(file.getName())) {
+            return DataCloudTags.FILE_ADD_ERROR_EXIST_READ_ONLY;
+        }
+
+        // check storage space first
+        if (getStorageList().isEmpty()) {
+            return DataCloudTags.FILE_ADD_ERROR_STORAGE_FULL;
+        }
+
+        for (final FileStorage storage : getStorageList()) {
+            if (storage.isResourceAmountAvailable((long) file.getSize())) {
+                storage.addFile(file);
+                return DataCloudTags.FILE_ADD_SUCCESSFUL;
+            }
+        }
+
+        return DataCloudTags.FILE_ADD_ERROR_STORAGE_FULL;
+    }
+}

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/builders/DatacenterBuilder.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/builders/DatacenterBuilder.java
@@ -90,7 +90,6 @@ public class DatacenterBuilder extends Builder {
         final String name = String.format(DC_NAME_FORMAT, createdDatacenters++);
         final Datacenter datacenter =
                 new DatacenterSimple(scenario.getSimulation(), hosts, new VmAllocationPolicySimple())
-                    .setStorageList(storageList)
                     .setSchedulingInterval(schedulingInterval);
 
         datacenter.getCharacteristics()
@@ -99,7 +98,8 @@ public class DatacenterBuilder extends Builder {
             .setCostPerMem(costPerMem)
             .setCostPerStorage(costPerStorage)
             .setCostPerBw(costPerBwMegabit);
-
+        
+        datacenter.getDatacenterStorage().setStorageList(storageList);
         datacenter.setName(name);
         this.datacenters.add(datacenter);
         return this;

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/datacenters/DatacenterTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/datacenters/DatacenterTest.java
@@ -16,7 +16,6 @@ public class DatacenterTest {
     @Test
     public void testNullObject() {
         final Datacenter instance = Datacenter.NULL;
-        assertEquals(0, instance.addFile(null));
         assertEquals(-1, instance.getId());
         assertEquals(0, instance.getSchedulingInterval(), 0);
         assertTrue(instance.getHostList().isEmpty());


### PR DESCRIPTION
#### Closes #141 

#### Where should the reviewer start?
DatacenterSimple had:
1.the storageList attribute, getter and setter
2.addFile and the two contains methods
3.setAllFilesOfAllStoragesToThisDatacenter method
4.predictFileTransferTime and timeToTransferFileFromStorage
,all moved to new class DatacenterStorage in resources package (had to change the name since the new object is not a list its an object that has a list so naming it StorageList will create too much confusion!)
DatacenterSimple has now a new object of DatacenterStorage with getter and setter

#### Any additional information you want to provide?
This implied changes to the following classes:
DatacenterNull
Datacenter (since it has prototypes of getter and setter of the moved storageList)
DatacenterBuilder
StorageAreaNetworkExample1
DatacenterTest

#### PS:
Allow edits from maintainers was checked for this pull request