### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -624,7 +624,7 @@ CloudletSchedulerSpaceShared and CloudletSchedulerTimeShared to CloudletSchedule
     - The class used a lot of hard-coded values for creating objects such as Cloudlets and VMs,
     that doesn't make sense once these values have to be defined by the developer creating
     the simulation. It was clear that the values were defined just to perform the simulations
-    presented at the paper ["NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations"](http://dx.doi.org/10.1109/UCC.2011.24). 
+    presented at the paper ["NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations"](https://doi.org/10.1109/UCC.2011.24). 
     By this way, they aren't useful for other users
     which desire to create their own simulations. Further, the creation of hard-coded Cloudlets and VMs inside
     the NetDatacenterBroker doesn't make it to be reusable and even violates the 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyFirstFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyFirstFit.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  * <p>If you are using any algorithms, policies or workload included in the power package please cite
  * the following paper:
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationAbstract.java
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toSet;
  * power package please cite the following paper:
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and
  * Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of
  * Virtual Machines in Cloud Data Centers", Concurrency and Computation:

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationInterQuartileRange.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationInterQuartileRange.java
@@ -22,7 +22,7 @@ import org.cloudbus.cloudsim.util.MathUtil;
  * the following paper:</p>
  * <p>
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegression.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegression.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * <p>If you are using any algorithms, policies or workload included in the power package please cite
  * the following paper:
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegressionRobust.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegressionRobust.java
@@ -20,7 +20,7 @@ import org.cloudbus.cloudsim.util.MathUtil;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationMedianAbsoluteDeviation.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationMedianAbsoluteDeviation.java
@@ -20,7 +20,7 @@ import org.cloudbus.cloudsim.util.MathUtil;
  * <p>If you are using any algorithms, policies or workload included in the power package please cite
  * the following paper:
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationStaticThreshold.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationStaticThreshold.java
@@ -25,7 +25,7 @@ import java.util.function.Function;
  * If you are using any algorithms, policies or workload included in the power
  * package please cite the following paper:
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and
  * Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of
  * Virtual Machines in Cloud Data Centers", Concurrency and Computation:

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletExecutionTask.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletExecutionTask.java
@@ -15,7 +15,7 @@ package org.cloudbus.cloudsim.cloudlets.network;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletReceiveTask.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletReceiveTask.java
@@ -24,7 +24,7 @@ import java.util.List;
  * Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletSendTask.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletSendTask.java
@@ -22,7 +22,7 @@ import org.cloudbus.cloudsim.network.VmPacket;
  * Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.java
@@ -17,7 +17,7 @@ import org.cloudbus.cloudsim.core.Identifiable;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  * Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/network/NetworkDatacenter.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/datacenters/network/NetworkDatacenter.java
@@ -29,7 +29,7 @@ import static java.util.stream.Collectors.toList;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/hosts/network/NetworkHost.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/hosts/network/NetworkHost.java
@@ -36,7 +36,7 @@ import java.util.List;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/HostPacket.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/HostPacket.java
@@ -18,7 +18,7 @@ import org.cloudbus.cloudsim.hosts.network.NetworkHost;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/VmPacket.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/VmPacket.java
@@ -19,7 +19,7 @@ import org.cloudbus.cloudsim.vms.Vm;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/package-info.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/package-info.java
@@ -9,7 +9,7 @@
  * For more information about the network moduule, please refer to following publication:
  * <ul>
  * <li>
- *   <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ *   <a href="https://doi.org/10.1109/UCC.2011.24">
  *   Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  *   Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  *   International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/switches/AggregateSwitch.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/switches/AggregateSwitch.java
@@ -21,7 +21,7 @@ import org.cloudbus.cloudsim.vms.Vm;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/switches/EdgeSwitch.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/switches/EdgeSwitch.java
@@ -22,7 +22,7 @@ import org.cloudbus.cloudsim.vms.Vm;
  * <br>Please refer to following publication for more details:<br>
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/switches/RootSwitch.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/switches/RootSwitch.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModel.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModel.java
@@ -27,7 +27,7 @@ import org.cloudbus.cloudsim.hosts.Host;
  * power package please cite the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and
  * Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of
  * Virtual Machines in Cloud Data Centers", Concurrency and Computation:

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelCubic.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelCubic.java
@@ -15,7 +15,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelLinear.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelLinear.java
@@ -15,7 +15,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPower.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPower.java
@@ -16,7 +16,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G3PentiumD930.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G3PentiumD930.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G4Xeon3040.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G4Xeon3040.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G5Xeon3075.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G5Xeon3075.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3470.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3470.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3480.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3480.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5670.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5670.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5675.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5675.java
@@ -17,7 +17,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSqrt.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSqrt.java
@@ -15,7 +15,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:</p>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSquare.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelSquare.java
@@ -15,7 +15,7 @@ package org.cloudbus.cloudsim.power.models;
  * the following paper:
  * </p>
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a></li>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerCompletelyFair.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerCompletelyFair.java
@@ -111,8 +111,8 @@ import static java.util.stream.Collectors.toList;
  *
  * @see <a href="http://www.ibm.com/developerworks/library/l-completely-fair-scheduler/">Inside the Linux 2.6 Completely Fair Scheduler</a>
  * @see <a href="http://www.ibm.com/developerworks/library/l-lpic1-103-6/index.html">Learn Linux, 101: Process execution priorities</a>
- * @see <a href="http://dx.doi.org/10.1145/1400097.1400102">Towards achieving fairness in the Linux scheduler</a>
- * @see <a href="http://dx.doi.org/10.1145/10.1145/2901318.2901326">The Linux scheduler</a>
+ * @see <a href="https://doi.org/10.1145/1400097.1400102">Towards achieving fairness in the Linux scheduler</a>
+ * @see <a href="https://doi.org/10.1145/10.1145/2901318.2901326">The Linux scheduler</a>
  * @see <a href="https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt">kernel.org: CFS Scheduler Design</a>
  * @see <a href="https://oakbytes.wordpress.com/linux-scheduler/">Linux Scheduler FAQ</a>
  */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicy.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicy.java
@@ -22,7 +22,7 @@ import org.cloudbus.cloudsim.vms.Vm;
  * the following paper:<br/>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMaximumCorrelation.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMaximumCorrelation.java
@@ -26,7 +26,7 @@ import java.util.Map;
  * the following paper:<br/>
  * <p>
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumMigrationTime.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumMigrationTime.java
@@ -20,7 +20,7 @@ import org.cloudbus.cloudsim.vms.Vm;
  * the following paper:<br/>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumUtilization.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumUtilization.java
@@ -24,7 +24,7 @@ import java.util.function.Predicate;
  * the following paper:<br/>
  * <p>
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyRandomSelection.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyRandomSelection.java
@@ -22,7 +22,7 @@ import org.cloudbus.cloudsim.vms.Vm;
  * the following paper:<br/>
  *
  * <ul>
- * <li><a href="http://dx.doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
+ * <li><a href="https://doi.org/10.1002/cpe.1867">Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive
  * Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in
  * Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24,
  * Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012</a>

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/network/NetworkVm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/network/NetworkVm.java
@@ -25,7 +25,7 @@ import java.util.List;
  * <p>Please refer to following publication for more details:
  * <ul>
  * <li>
- * <a href="http://dx.doi.org/10.1109/UCC.2011.24">
+ * <a href="https://doi.org/10.1109/UCC.2011.24">
  * Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel
  * Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM
  * International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/SimulatedAnnealing.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/SimulatedAnnealing.java
@@ -56,7 +56,7 @@ import org.cloudbus.cloudsim.distributions.ContinuousDistribution;
  * @param <S> the class of solutions the heuristic will deal with, starting with a random solution
  *           and execute the solution search in order to achieve a satisfying solution (defined by a stop criteria)
  * @author Manoel Campos da Silva Filho
- * @see <a href="http://dx.doi.org/10.1109/101.17235">[1] R. A. Rutenbar,
+ * @see <a href="https://doi.org/10.1109/101.17235">[1] R. A. Rutenbar,
  * “Simulated Annealing Algorithms: An overview,” IEEE Circuits Devices Mag., vol. 1, no. 5,
  * pp. 19–26, 1989.</a>
  * @since CloudSim Plus 1.0

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyFirstFit.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyFirstFit.rst
@@ -20,7 +20,7 @@ VmAllocationPolicyFirstFit
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationAbstract.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationAbstract.rst
@@ -38,7 +38,7 @@ VmAllocationPolicyMigrationAbstract
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationInterQuartileRange.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationInterQuartileRange.rst
@@ -18,7 +18,7 @@ VmAllocationPolicyMigrationInterQuartileRange
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegression.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegression.rst
@@ -22,7 +22,7 @@ VmAllocationPolicyMigrationLocalRegression
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegressionRobust.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationLocalRegressionRobust.rst
@@ -16,7 +16,7 @@ VmAllocationPolicyMigrationLocalRegressionRobust
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationMedianAbsoluteDeviation.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationMedianAbsoluteDeviation.rst
@@ -18,7 +18,7 @@ VmAllocationPolicyMigrationMedianAbsoluteDeviation
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationStaticThreshold.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/allocationpolicies/migration/VmAllocationPolicyMigrationStaticThreshold.rst
@@ -26,7 +26,7 @@ VmAllocationPolicyMigrationStaticThreshold
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletExecutionTask.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletExecutionTask.rst
@@ -12,7 +12,7 @@ CloudletExecutionTask
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletReceiveTask.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletReceiveTask.rst
@@ -22,7 +22,7 @@ CloudletReceiveTask
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletSendTask.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletSendTask.rst
@@ -22,7 +22,7 @@ CloudletSendTask
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/CloudletTask.rst
@@ -18,7 +18,7 @@ CloudletTask
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg
 

--- a/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/cloudlets/network/NetworkCloudlet.rst
@@ -22,7 +22,7 @@ NetworkCloudlet
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/datacenters/network/NetworkDatacenter.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/datacenters/network/NetworkDatacenter.rst
@@ -34,7 +34,7 @@ NetworkDatacenter
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/hosts/network/NetworkHost.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/hosts/network/NetworkHost.rst
@@ -46,7 +46,7 @@ NetworkHost
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg
 

--- a/docs/javadocs/org/cloudbus/cloudsim/network/HostPacket.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/network/HostPacket.rst
@@ -16,7 +16,7 @@ HostPacket
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/network/VmPacket.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/network/VmPacket.rst
@@ -18,7 +18,7 @@ VmPacket
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/network/package-index.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/network/package-index.rst
@@ -7,7 +7,7 @@ It also provides class to enable simulation of network package transmission. For
 
 ..
 
-* \ ` Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+* \ ` Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
 :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/network/switches/AggregateSwitch.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/network/switches/AggregateSwitch.rst
@@ -24,7 +24,7 @@ AggregateSwitch
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/network/switches/EdgeSwitch.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/network/switches/EdgeSwitch.rst
@@ -24,7 +24,7 @@ EdgeSwitch
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/network/switches/RootSwitch.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/network/switches/RootSwitch.rst
@@ -28,7 +28,7 @@ RootSwitch
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModel.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModel.rst
@@ -18,7 +18,7 @@ PowerModel
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelCubic.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelCubic.rst
@@ -12,7 +12,7 @@ PowerModelCubic
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelLinear.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelLinear.rst
@@ -12,7 +12,7 @@ PowerModelLinear
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPower.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPower.rst
@@ -12,7 +12,7 @@ PowerModelSpecPower
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G3PentiumD930.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G3PentiumD930.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerHpProLiantMl110G3PentiumD930
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G4Xeon3040.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G4Xeon3040.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerHpProLiantMl110G4Xeon3040
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G5Xeon3075.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerHpProLiantMl110G5Xeon3075.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerHpProLiantMl110G5Xeon3075
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3470.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3470.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerIbmX3250XeonX3470
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3480.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3250XeonX3480.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerIbmX3250XeonX3480
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5670.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5670.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerIbmX3550XeonX5670
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5675.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSpecPowerIbmX3550XeonX5675.rst
@@ -12,7 +12,7 @@ PowerModelSpecPowerIbmX3550XeonX5675
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSqrt.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSqrt.rst
@@ -12,7 +12,7 @@ PowerModelSqrt
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSquare.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/power/models/PowerModelSquare.rst
@@ -12,7 +12,7 @@ PowerModelSquare
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov, Manoel Campos da Silva Filho
 

--- a/docs/javadocs/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerCompletelyFair.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerCompletelyFair.rst
@@ -52,7 +52,7 @@ CloudletSchedulerCompletelyFair
 
    :author: Manoel Campos da Silva Filho
 
-   **See also:** \ `Inside the Linux 2.6 Completely Fair Scheduler <http://www.ibm.com/developerworks/library/l-completely-fair-scheduler/>`_\, \ `Learn Linux, 101: Process execution priorities <http://www.ibm.com/developerworks/library/l-lpic1-103-6/index.html>`_\, \ `Towards achieving fairness in the Linux scheduler <http://dx.doi.org/10.1145/1400097.1400102>`_\, \ `The Linux scheduler <http://dx.doi.org/10.1145/10.1145/2901318.2901326>`_\, \ `kernel.org: CFS Scheduler Design <https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt>`_\, \ `Linux Scheduler FAQ <https://oakbytes.wordpress.com/linux-scheduler/>`_\
+   **See also:** \ `Inside the Linux 2.6 Completely Fair Scheduler <http://www.ibm.com/developerworks/library/l-completely-fair-scheduler/>`_\, \ `Learn Linux, 101: Process execution priorities <http://www.ibm.com/developerworks/library/l-lpic1-103-6/index.html>`_\, \ `Towards achieving fairness in the Linux scheduler <https://doi.org/10.1145/1400097.1400102>`_\, \ `The Linux scheduler <https://doi.org/10.1145/10.1145/2901318.2901326>`_\, \ `kernel.org: CFS Scheduler Design <https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt>`_\, \ `Linux Scheduler FAQ <https://oakbytes.wordpress.com/linux-scheduler/>`_\
 
 Methods
 -------

--- a/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicy.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicy.rst
@@ -18,7 +18,7 @@ PowerVmSelectionPolicy
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMaximumCorrelation.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMaximumCorrelation.rst
@@ -26,7 +26,7 @@ PowerVmSelectionPolicyMaximumCorrelation
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumMigrationTime.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumMigrationTime.rst
@@ -16,7 +16,7 @@ PowerVmSelectionPolicyMinimumMigrationTime
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumUtilization.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyMinimumUtilization.rst
@@ -24,7 +24,7 @@ PowerVmSelectionPolicyMinimumUtilization
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyRandomSelection.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/selectionpolicies/power/PowerVmSelectionPolicyRandomSelection.rst
@@ -20,7 +20,7 @@ PowerVmSelectionPolicyRandomSelection
 
    ..
 
-   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <http://dx.doi.org/10.1002/cpe.1867>`_\
+   * \ `Anton Beloglazov, and Rajkumar Buyya, "Optimal Online Deterministic Algorithms and Adaptive Heuristics for Energy and Performance Efficient Dynamic Consolidation of Virtual Machines in Cloud Data Centers", Concurrency and Computation: Practice and Experience (CCPE), Volume 24, Issue 13, Pages: 1397-1420, John Wiley & Sons, Ltd, New York, USA, 2012 <https://doi.org/10.1002/cpe.1867>`_\
 
    :author: Anton Beloglazov
 

--- a/docs/javadocs/org/cloudbus/cloudsim/vms/network/NetworkVm.rst
+++ b/docs/javadocs/org/cloudbus/cloudsim/vms/network/NetworkVm.rst
@@ -28,7 +28,7 @@ NetworkVm
 
    ..
 
-   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <http://dx.doi.org/10.1109/UCC.2011.24>`_\
+   * \ `Saurabh Kumar Garg and Rajkumar Buyya, NetworkCloudSim: Modelling Parallel Applications in Cloud Simulations, Proceedings of the 4th IEEE/ACM International Conference on Utility and Cloud Computing (UCC 2011, IEEE CS Press, USA), Melbourne, Australia, December 5-7, 2011. <https://doi.org/10.1109/UCC.2011.24>`_\
 
    :author: Saurabh Kumar Garg
 

--- a/docs/javadocs/org/cloudsimplus/heuristics/SimulatedAnnealing.rst
+++ b/docs/javadocs/org/cloudsimplus/heuristics/SimulatedAnnealing.rst
@@ -29,7 +29,7 @@ SimulatedAnnealing
    :author: Manoel Campos da Silva Filho
    :param <S>: the class of solutions the heuristic will deal with, starting with a random solution and execute the solution search in order to achieve a satisfying solution (defined by a stop criteria)
 
-   **See also:** \ `[1] R. A. Rutenbar, “Simulated Annealing Algorithms: An overview,” IEEE Circuits Devices Mag., vol. 1, no. 5, pp. 19–26, 1989. <http://dx.doi.org/10.1109/101.17235>`_\
+   **See also:** \ `[1] R. A. Rutenbar, “Simulated Annealing Algorithms: An overview,” IEEE Circuits Devices Mag., vol. 1, no. 5, pp. 19–26, 1989. <https://doi.org/10.1109/101.17235>`_\
 
 Constructors
 ------------


### PR DESCRIPTION
#### What's this Pull Request does, clear and precisely?

Updates all static DOI links to the [DOI foundation's new, recommended resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). The old links with the `dx` subdomain continue to work, though.

The other items are not really relevant, I think, as this PR isn't changing actual code.