### PR TITLE
Update VmSchedulerAbstract.java

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/vm/VmSchedulerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/vm/VmSchedulerAbstract.java
@@ -171,7 +171,7 @@ public abstract class VmSchedulerAbstract implements VmScheduler {
         //Gets the total virtual PEs of currently created VMs
         final long totalVirtualPesNumber = getAllocatedMipsMap().values().stream().mapToLong(Collection::size).sum();
         final List<Pe> peList = getHost().getBuzyPeList();
-        final long vPesNumber = Math.min(peList.size() - totalVirtualPesNumber, 0);
+        final long vPesNumber = Math.max(peList.size() - totalVirtualPesNumber, 0);
         setHostPesStatusForVmUsedPes(peList, Pe.Status.FREE, vPesNumber);
     }
 


### PR DESCRIPTION
There seems to be a bug in VmSchedulerAbstract freeUsedPes. Because of the Math.min there are never Pes freed. Instead Math.max should be used.