### PR TITLE
Fixes a bug in selecting random entries in CloudletToVmMappingSolution

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
@@ -49,6 +49,8 @@ import org.cloudsimplus.heuristics.CloudletToVmMappingHeuristic;
 import org.cloudsimplus.heuristics.CloudletToVmMappingSimulatedAnnealing;
 import org.cloudsimplus.heuristics.CloudletToVmMappingSolution;
 import org.cloudsimplus.heuristics.HeuristicSolution;
+import org.cloudsimplus.util.Log;
+import ch.qos.logback.classic.Level;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -117,7 +119,7 @@ public class DatacenterBrokerHeuristicExample {
     public DatacenterBrokerHeuristicExample() {
         /*Enables just some level of log messages.
           Make sure to import org.cloudsimplus.util.Log;*/
-        //Log.setLevel(ch.qos.logback.classic.Level.WARN);
+        Log.setLevel(Level.WARN);
 
         System.out.println("Starting " + getClass().getSimpleName());
         this.vmList = new ArrayList<>();
@@ -171,14 +173,14 @@ public class DatacenterBrokerHeuristicExample {
 	}
 
 	private void print(DatacenterBrokerHeuristic broker0) {
-		double roudRobinMappingCost = computeRoudRobinMappingCost();
+		double roundRobinMappingCost = computeRoundRobinMappingCost();
 		printSolution(
 		        "Heuristic solution for mapping cloudlets to Vm's         ",
 		        heuristic.getBestSolutionSoFar(), false);
 
 		System.out.printf(
 		    "The heuristic solution cost represents %.2f%% of the round robin mapping cost used by the DatacenterBrokerSimple\n",
-		    heuristic.getBestSolutionSoFar().getCost()*100.0/roudRobinMappingCost);
+		    heuristic.getBestSolutionSoFar().getCost()*100.0/roundRobinMappingCost);
 		System.out.printf("The solution finding spend %.2f seconds to finish\n", broker0.getHeuristic().getSolveTime());
 		System.out.println("Simulated Annealing Parameters");
 		System.out.printf("\tInitial Temperature: %.2f", SA_INITIAL_TEMPERATURE);
@@ -252,19 +254,19 @@ public class DatacenterBrokerHeuristicExample {
         .setUtilizationModel(utilization);
     }
 
-    private double computeRoudRobinMappingCost() {
-        CloudletToVmMappingSolution roudRobinSolution =
+    private double computeRoundRobinMappingCost() {
+        CloudletToVmMappingSolution roundRobinSolution =
                 new CloudletToVmMappingSolution(heuristic);
         int i = 0;
         for (Cloudlet c : cloudletList) {
             //cyclically selects a Vm (as in a circular queue)
-            roudRobinSolution.bindCloudletToVm(c, vmList.get(i));
+            roundRobinSolution.bindCloudletToVm(c, vmList.get(i));
             i = (i+1) % vmList.size();
         }
         printSolution(
             "Round robin solution used by DatacenterBrokerSimple class",
-            roudRobinSolution, false);
-        return roudRobinSolution.getCost();
+            roundRobinSolution, false);
+        return roundRobinSolution.getCost();
     }
 
     private void printSolution(String title,

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
@@ -25,6 +25,7 @@ package org.cloudsimplus.examples.brokers;
 
 import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicySimple;
 import org.cloudbus.cloudsim.brokers.DatacenterBroker;
+import org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic;
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.cloudlets.CloudletSimple;
 import org.cloudbus.cloudsim.core.CloudSim;
@@ -60,13 +61,13 @@ import java.util.Map;
  * DatacenterBroker. The number of {@link Pe}s of Vm's and Cloudlets are defined
  * randomly.
  *
- * <p>The {@link org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic} is used
+ * <p>The {@link DatacenterBrokerHeuristic} is used
  * with the {@link CloudletToVmMappingSimulatedAnnealing} class
  * in order to find an acceptable solution with a high
  * {@link HeuristicSolution#getFitness() fitness value}.</p>
  *
  * <p>Different {@link CloudletToVmMappingHeuristic} implementations can be used
- * with the {@link org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic} class.</p>
+ * with the {@link DatacenterBrokerHeuristic} class.</p>
  *
  * @author Manoel Campos da Silva Filho
  * @since CloudSim Plus 1.0
@@ -126,7 +127,7 @@ public class DatacenterBrokerHeuristicExample {
 
         Datacenter datacenter0 = createDatacenter();
 
-        org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic broker0 = createBroker();
+        DatacenterBrokerHeuristic broker0 = createBroker();
 
         createAndSubmitVms(broker0);
         createAndSubmitCloudlets(broker0);
@@ -139,21 +140,21 @@ public class DatacenterBrokerHeuristicExample {
         print(broker0);
     }
 
-	private org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic createBroker() {
+	private DatacenterBrokerHeuristic createBroker() {
 		createSimulatedAnnealingHeuristic();
-		org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic broker0 = new org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic(simulation);
+		DatacenterBrokerHeuristic broker0 = new DatacenterBrokerHeuristic(simulation);
 		broker0.setHeuristic(heuristic);
 		return broker0;
 	}
 
-	private void createAndSubmitCloudlets(org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic broker0) {
+	private void createAndSubmitCloudlets(DatacenterBrokerHeuristic broker0) {
 		for(int i = 0; i < CLOUDLETS_TO_CREATE; i++){
 		    cloudletList.add(createCloudlet(broker0, getRandomNumberOfPes(4)));
 		}
 		broker0.submitCloudletList(cloudletList);
 	}
 
-	private void createAndSubmitVms(org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic broker0) {
+	private void createAndSubmitVms(DatacenterBrokerHeuristic broker0) {
 		vmList = new ArrayList<>(VMS_TO_CREATE);
 		for(int i = 0; i < VMS_TO_CREATE; i++){
 		    vmList.add(createVm(broker0, getRandomNumberOfPes(4)));
@@ -169,7 +170,7 @@ public class DatacenterBrokerHeuristicExample {
 		heuristic.setNeighborhoodSearchesByIteration(SA_NUMBER_OF_NEIGHBORHOOD_SEARCHES);
 	}
 
-	private void print(org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic broker0) {
+	private void print(DatacenterBrokerHeuristic broker0) {
 		double roudRobinMappingCost = computeRoudRobinMappingCost();
 		printSolution(
 		        "Heuristic solution for mapping cloudlets to Vm's         ",

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/CloudletToVmMappingSolution.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/CloudletToVmMappingSolution.java
@@ -345,11 +345,10 @@ public class CloudletToVmMappingSolution implements HeuristicSolution<Map<Cloudl
         until finding the required entries, without creating
         a List with all entries in order to get just two of them.
         */
-        for(int i = 0; selected.size() < 2 && it.hasNext(); ){
+        for(int i = 0; selected.size() < 2 && it.hasNext(); i++){
             final Map.Entry<Cloudlet, Vm> solution = it.next();
             if(i == firstIdx || i == secondIdx){
                 selected.add(solution);
-                i++;
             }
         }
 

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/CloudletToVmMappingSolution.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/CloudletToVmMappingSolution.java
@@ -339,8 +339,7 @@ public class CloudletToVmMappingSolution implements HeuristicSolution<Map<Cloudl
         /*
         Loop over the entries until the entries defined by the first and second index
         are found and added to the List.
-        Since there is not way to get the entries inside the map don't have a index,
-        we can't access the ith entry directly.
+        Since Map doesn't have an index, we can't access the ith entry directly.
         This loops ensure we iterate the the least number of times
         until finding the required entries, without creating
         a List with all entries in order to get just two of them.

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/Heuristic.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/Heuristic.java
@@ -23,6 +23,9 @@
  */
 package org.cloudsimplus.heuristics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * <p>Provides the methods to be used for implementation of heuristics
  * to find solution for complex problems where the solution space
@@ -48,6 +51,8 @@ package org.cloudsimplus.heuristics;
  * @since CloudSim Plus 1.0
  */
 public interface Heuristic<S extends HeuristicSolution<?>> {
+
+    Logger LOGGER = LoggerFactory.getLogger(Heuristic.class.getSimpleName());
 
     /**
      * A property that implements the Null Object Design Pattern for {@link Heuristic}

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/SimulatedAnnealing.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/SimulatedAnnealing.java
@@ -129,6 +129,7 @@ public abstract class SimulatedAnnealing<S extends HeuristicSolution<?>> extends
     @Override
     public void updateSystemState() {
 	    currentTemperature *= 1 - coolingRate;
+	    LOGGER.debug("{}: Best solution cost so far is {}, current system temperature is {}", System.currentTimeMillis(), getBestSolutionSoFar().getCost(), getCurrentTemperature());
     }
 
     /**


### PR DESCRIPTION
This PR fixes bug in `createListWithTwoRandomEntries` the loop index `i` (see [here](https://github.com/manoelcampos/cloudsim-plus/blob/c8bdcf4181e485d570592ffc5c3b1e9212e976ac/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/CloudletToVmMappingSolution.java#L352)) was never incremented, thus the two random entries were never selected.

Additionally, following minor fixes are also pushed:

- Add Logger in `Heuristic` classes.
- Fixed typos in `DatacenterBrokerHeuristicExample`
- Remove package name before the `DatacenterBrokerHeuristic` class name. Not needed since the example name has no conflicts now.