### PR TITLE
Adds DatacenterBrokerBestFit, an implementation of DatacenterBroker with a best fit Cloudlet to VM mapper

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java
@@ -128,7 +128,7 @@ public class CloudletToVmMappingBestFit {
      * @return the VM selected for the Cloudlet or {@link Vm#NULL} if no suitable VM was found
      */
     private Vm bestFitCloudletToVmMapper(final Cloudlet cloudlet) {
-        if (cloudlet.isBindToVm() && broker0.equals(cloudlet.getVm().getBroker()) && cloudlet.getVm().isCreated()) {
+        if (cloudlet.isBoundToVm() && broker0.equals(cloudlet.getVm().getBroker()) && cloudlet.getVm().isCreated()) {
             return cloudlet.getVm();
         }
 

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java
@@ -65,7 +65,7 @@ import java.util.List;
  * </p>
  *
  * @author Manoel Campos da Silva Filho
- * @since CloudSim Plus 4.3.8
+ * @since CloudSim Plus 1.3.0
  */
 public class CloudletToVmMappingBestFit {
     private static final int HOSTS = 2;

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java
@@ -60,7 +60,7 @@ import java.util.List;
  * changing the method used for that goal,
  * without requiring to create a subclass to accomplish that.</p>
  *
- * <p>The example uses the class {@link DatacenterBrokerBestFit} that
+ * <p>The example uses the class {@link DatacenterBrokerBestFit} that performs
  * an optimal mapping of Cloudlets to VMs based on the free Pes in VMs.
  * </p>
  *

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
@@ -141,7 +141,7 @@ public class DatacenterBrokerHeuristicExample {
 
         // false: for the best fit version in the CloudletToVmMappingBestFit example
         // true: for the best fit broker
-        boolean useBestFitBroker = false;
+        boolean useBestFitBroker = true;
         seed = 0;
 
         // Heuristic
@@ -168,11 +168,11 @@ public class DatacenterBrokerHeuristicExample {
         final Datacenter datacenter1 = createDatacenter(simulation1);
 
         if (useBestFitBroker) {
-            broker1 = new DatacenterBrokerSimple(simulation1);
-            broker1.setVmMapper(this::bestFitCloudletToVmMapper);
+            broker1 = new DatacenterBrokerBestFit(simulation1);
         }
         else {
-            broker1 = new DatacenterBrokerBestFit(simulation1);
+            broker1 = new DatacenterBrokerSimple(simulation1);
+            broker1.setVmMapper(this::bestFitCloudletToVmMapper);
         }
 
         vmList1 = createVms(random1);

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokerHeuristicExample.java
@@ -119,7 +119,7 @@ public class DatacenterBrokerHeuristicExample {
     /**
      * Seed.
      */
-    long seed;
+    private final long seed;
     UniformDistr random0, random1;
 
     /**

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -1,0 +1,349 @@
+/*
+ * CloudSim Plus: A modern, highly-extensible and easier-to-use Framework for
+ * Modeling and Simulation of Cloud Computing Infrastructures and Services.
+ * http://cloudsimplus.org
+ *
+ *     Copyright (C) 2015-2018 Universidade da Beira Interior (UBI, Portugal) and
+ *     the Instituto Federal de Educação Ciência e Tecnologia do Tocantins (IFTO, Brazil).
+ *
+ *     This file is part of CloudSim Plus.
+ *
+ *     CloudSim Plus is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     CloudSim Plus is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ *     You should have received a copy of the GNU General Public License
+ *     along with CloudSim Plus. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.cloudsimplus.examples.brokers;
+
+import ch.qos.logback.classic.Level;
+import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicySimple;
+import org.cloudbus.cloudsim.brokers.DatacenterBroker;
+import org.cloudbus.cloudsim.brokers.DatacenterBrokerBestFit;
+import org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic;
+import org.cloudbus.cloudsim.brokers.DatacenterBrokerSimple;
+import org.cloudbus.cloudsim.cloudlets.Cloudlet;
+import org.cloudbus.cloudsim.cloudlets.CloudletSimple;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.core.Simulation;
+import org.cloudbus.cloudsim.datacenters.Datacenter;
+import org.cloudbus.cloudsim.datacenters.DatacenterSimple;
+import org.cloudbus.cloudsim.distributions.ContinuousDistribution;
+import org.cloudbus.cloudsim.distributions.UniformDistr;
+import org.cloudbus.cloudsim.hosts.Host;
+import org.cloudbus.cloudsim.hosts.HostSimple;
+import org.cloudbus.cloudsim.provisioners.PeProvisionerSimple;
+import org.cloudbus.cloudsim.provisioners.ResourceProvisionerSimple;
+import org.cloudbus.cloudsim.resources.Pe;
+import org.cloudbus.cloudsim.resources.PeSimple;
+import org.cloudbus.cloudsim.schedulers.cloudlet.CloudletSchedulerTimeShared;
+import org.cloudbus.cloudsim.schedulers.vm.VmSchedulerTimeShared;
+import org.cloudbus.cloudsim.utilizationmodels.UtilizationModel;
+import org.cloudbus.cloudsim.utilizationmodels.UtilizationModelFull;
+import org.cloudbus.cloudsim.vms.Vm;
+import org.cloudbus.cloudsim.vms.VmSimple;
+import org.cloudsimplus.builders.tables.CloudletsTableBuilder;
+import org.cloudsimplus.heuristics.*;
+import org.cloudsimplus.util.Log;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An example that uses a
+ * <a href="http://en.wikipedia.org/wiki/Simulated_annealing">Simulated Annealing</a>
+ * heuristic to find a suboptimal mapping between Cloudlets and Vm's submitted to a
+ * DatacenterBroker. The number of {@link Pe}s of Vm's and Cloudlets are defined
+ * randomly.
+ *
+ * <p>The {@link DatacenterBrokerHeuristic} is used
+ * with the {@link CloudletToVmMappingSimulatedAnnealing} class
+ * in order to find an acceptable solution with a high
+ * {@link HeuristicSolution#getFitness() fitness value}.</p>
+ *
+ * <p>Different {@link CloudletToVmMappingHeuristic} implementations can be used
+ * with the {@link DatacenterBrokerHeuristic} class.</p>
+ *
+ * <p>A comparison of cloudlet-VM mapping is done among the best fit approach,
+ * heuristic approach and round robin mapping.</p>
+ *
+ * @author Manoel Campos da Silva Filho
+ * @since CloudSim Plus 1.0
+ */
+public class DatacenterBrokerHeuristicExample {
+    private static final int HOSTS_TO_CREATE = 100;
+    private static final int VMS_TO_CREATE = 50;
+    private static final int CLOUDLETS_TO_CREATE = 100;
+
+    /**
+     * Simulated Annealing (SA) parameters.
+     */
+    public static final double SA_INITIAL_TEMPERATURE = 1.0;
+    public static final double SA_COLD_TEMPERATURE = 0.0001;
+    public static final double SA_COOLING_RATE = 0.003;
+    public static final int    SA_NUMBER_OF_NEIGHBORHOOD_SEARCHES = 50;
+
+    private final Simulation simulation;
+    private final List<Cloudlet> cloudletList;
+    private List<Vm> vmList;
+
+    /**
+     * Number of cloudlets created so far.
+     */
+    private int createdCloudlets = 0;
+    /**
+     * Number of VMs created so far.
+     */
+    private int createdVms = 0;
+    /**
+     * Number of hosts created so far.
+     */
+    private int createdHosts = 0;
+    /**
+     * Broker.
+     */
+    private DatacenterBroker broker;
+
+    ContinuousDistribution random;
+
+    /**
+     * Starts the simulation.
+     * @param args
+     */
+    public static void main(String[] args) {
+        final long seed = 0;
+        final boolean showTables = false;
+
+        // Heuristic
+        final CloudSim simulation0 = new CloudSim();
+        UniformDistr random0 = new UniformDistr(0, 1, seed);
+        final DatacenterBrokerHeuristic broker0 = createHeuristicBroker(simulation0, random0);
+        new DatacenterBrokerHeuristicExample(broker0, random0, showTables);
+
+        // BestFit
+        final CloudSim simulation1 = new CloudSim();
+        UniformDistr random1 = new UniformDistr(0, 1, seed);
+        final DatacenterBroker broker1 = new DatacenterBrokerBestFit(simulation1);
+        new DatacenterBrokerHeuristicExample(broker1, random1, showTables);
+
+        // Simple - RoundRobin
+        final CloudSim simulation2 = new CloudSim();
+        UniformDistr random2 = new UniformDistr(0, 1, seed);
+        final DatacenterBroker broker2 = new DatacenterBrokerSimple(simulation2);
+        new DatacenterBrokerHeuristicExample(broker2, random2, showTables);
+    }
+
+    /**
+     * Default constructor where the simulation is built.
+     */
+    public DatacenterBrokerHeuristicExample(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean showTables) {
+        //Enables just some level of log messages.
+        Log.setLevel(Level.ERROR);
+
+        System.out.println("Starting " + getClass().getSimpleName());
+
+        broker = brkr;
+        simulation = broker.getSimulation();
+        random = rand;
+
+        final Datacenter datacenter = createDatacenter(simulation);
+
+        vmList = createVms(random);
+        cloudletList = createCloudlets(random);
+        broker.submitVmList(vmList);
+        broker.submitCloudletList(cloudletList);
+
+        simulation.start();
+
+        // print simulation results
+        if (showTables) {
+            final List<Cloudlet> finishedCloudlets = broker.getCloudletFinishedList();
+            finishedCloudlets.sort(Comparator.comparingLong(Cloudlet::getId));
+            new CloudletsTableBuilder(finishedCloudlets).build();
+        }
+
+        print();
+    }
+
+    private static DatacenterBrokerHeuristic createHeuristicBroker(final CloudSim sim, final ContinuousDistribution rand) {
+        CloudletToVmMappingSimulatedAnnealing heuristic = createSimulatedAnnealingHeuristic(rand);
+		final DatacenterBrokerHeuristic broker = new DatacenterBrokerHeuristic(sim);
+		broker.setHeuristic(heuristic);
+		return broker;
+	}
+
+	private List<Cloudlet> createCloudlets(final ContinuousDistribution rand) {
+        final List<Cloudlet> list = new ArrayList<>(CLOUDLETS_TO_CREATE);
+		for(int i = 0; i < CLOUDLETS_TO_CREATE; i++){
+            list.add(createCloudlet(getRandomPesNumber(4, rand)));
+		}
+
+        return list;
+    }
+
+	private List<Vm> createVms(final ContinuousDistribution random) {
+        final List<Vm> list = new ArrayList<>(VMS_TO_CREATE);
+		for(int i = 0; i < VMS_TO_CREATE; i++){
+            list.add(createVm(getRandomPesNumber(4, random)));
+		}
+
+        return list;
+	}
+
+	private static CloudletToVmMappingSimulatedAnnealing createSimulatedAnnealingHeuristic(final ContinuousDistribution rand) {
+        CloudletToVmMappingSimulatedAnnealing heuristic =
+		        new CloudletToVmMappingSimulatedAnnealing(SA_INITIAL_TEMPERATURE, rand);
+		heuristic.setColdTemperature(SA_COLD_TEMPERATURE);
+		heuristic.setCoolingRate(SA_COOLING_RATE);
+		heuristic.setNeighborhoodSearchesByIteration(SA_NUMBER_OF_NEIGHBORHOOD_SEARCHES);
+		return heuristic;
+	}
+
+	private void print() {
+        final double brokersMappingCost = computeBrokersMappingCost(false);
+        final double basicRoundRobinCost = computeRoundRobinMappingCost(false);
+        System.out.printf(
+            "The solution based on %s mapper costs %.2f. Basic round robin implementation in this example costs %.2f.\n", broker.getClass().getSimpleName(), brokersMappingCost, basicRoundRobinCost);
+        System.out.println(getClass().getSimpleName() + " finished!");
+	}
+
+	/**
+     * Randomly gets a number of PEs (CPU cores).
+     *
+     * @param maxPesNumber the maximum value to get a random number of PEs
+     * @return the randomly generated PEs number
+     */
+    private int getRandomPesNumber(final int maxPesNumber, final ContinuousDistribution random) {
+        final double uniform = random.sample();
+
+        /*always get an index between [0 and size[,
+        regardless if the random number generator returns
+        values between [0 and 1[ or >= 1*/
+        return (int)(uniform >= 1 ? uniform % maxPesNumber : uniform * maxPesNumber) + 1;
+    }
+
+    private DatacenterSimple createDatacenter(final Simulation sim) {
+        final List<Host> hostList = new ArrayList<>();
+        for(int i = 0; i < HOSTS_TO_CREATE; i++) {
+            hostList.add(createHost());
+        }
+
+        return new DatacenterSimple(sim, hostList, new VmAllocationPolicySimple());
+    }
+
+    private Host createHost() {
+        final long mips = 1000; // capacity of each CPU core (in Million Instructions per Second)
+        final int  ram = 2048; // host memory (Megabyte)
+        final long storage = 1000000; // host storage
+        final long bw = 10000;
+
+        final List<Pe> peList = new ArrayList<>();
+        /*Creates the Host's CPU cores and defines the provisioner
+        used to allocate each core for requesting VMs.*/
+        for(int i = 0; i < 8; i++)
+            peList.add(new PeSimple(mips, new PeProvisionerSimple()));
+
+        createdHosts++;
+        return new HostSimple(ram, bw, storage, peList)
+                   .setRamProvisioner(new ResourceProvisionerSimple())
+                   .setBwProvisioner(new ResourceProvisionerSimple())
+                   .setVmScheduler(new VmSchedulerTimeShared());
+    }
+
+    private Vm createVm(final int pesNumber) {
+        final long mips = 1000;
+        final long   storage = 10000; // vm image size (Megabyte)
+        final int    ram = 512; // vm memory (Megabyte)
+        final long   bw = 1000; // vm bandwidth
+
+        return new VmSimple(createdVms++, mips, pesNumber)
+            .setRam(ram).setBw(bw).setSize(storage)
+            .setCloudletScheduler(new CloudletSchedulerTimeShared());
+    }
+
+    private Cloudlet createCloudlet(final int numberOfPes) {
+        final long length = 400000; //in Million Structions (MI)
+        final long fileSize = 300; //Size (in bytes) before execution
+        final long outputSize = 300; //Size (in bytes) after execution
+
+        //Defines how CPU, RAM and Bandwidth resources are used
+        //Sets the same utilization model for all these resources.
+        final UtilizationModel utilization = new UtilizationModelFull();
+
+        return new CloudletSimple(createdCloudlets++, length, numberOfPes)
+                    .setFileSize(fileSize)
+                    .setOutputSize(outputSize)
+                    .setUtilizationModel(utilization);
+    }
+
+    private double computeRoundRobinMappingCost(boolean doPrint) {
+        CloudletToVmMappingSimulatedAnnealing heuristic =
+            new CloudletToVmMappingSimulatedAnnealing(SA_INITIAL_TEMPERATURE, random);
+        final CloudletToVmMappingSolution roundRobinSolution = new CloudletToVmMappingSolution(heuristic);
+        int i = 0;
+        for (Cloudlet c : cloudletList) {
+            //cyclically selects a Vm (as in a circular queue)
+            roundRobinSolution.bindCloudletToVm(c, vmList.get(i));
+            i = (i+1) % vmList.size();
+        }
+
+        if (doPrint) {
+            printSolution(
+                "Round robin solution used by DatacenterBrokerSimple class",
+                roundRobinSolution, false);
+        }
+        return roundRobinSolution.getCost();
+    }
+
+    private double computeBrokersMappingCost(boolean doPrint) {
+        CloudletToVmMappingSimulatedAnnealing heuristic =
+            new CloudletToVmMappingSimulatedAnnealing(SA_INITIAL_TEMPERATURE, random);
+
+        final CloudletToVmMappingSolution bestFitSolution = new CloudletToVmMappingSolution(heuristic);
+        int i = 0;
+        for (Cloudlet c : cloudletList) {
+            if (c.isBoundToVm()) {
+                bestFitSolution.bindCloudletToVm(c, c.getVm());
+            }
+        }
+
+        if (doPrint) {
+            printSolution(
+                "Best fit solution used by DatacenterBrokerSimple class",
+                bestFitSolution, false);
+        }
+        return bestFitSolution.getCost();
+    }
+
+    private void printSolution(
+        final String title,
+        final CloudletToVmMappingSolution solution,
+        final boolean showIndividualCloudletFitness)
+    {
+        System.out.printf("%s (cost %.2f fitness %.6f)\n",
+                title, solution.getCost(), solution.getFitness());
+        if(!showIndividualCloudletFitness)
+            return;
+
+        for(Map.Entry<Cloudlet, Vm> e: solution.getResult().entrySet()){
+            System.out.printf(
+                "Cloudlet %3d (%d PEs, %6d MI) mapped to Vm %3d (%d PEs, %6.0f MIPS)\n",
+                e.getKey().getId(),
+                e.getKey().getNumberOfPes(), e.getKey().getLength(),
+                e.getValue().getId(),
+                e.getValue().getNumberOfPes(), e.getValue().getMips());
+        }
+
+        System.out.println();
+    }
+
+}

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -118,8 +118,10 @@ public class DatacenterBrokersMappingComparison {
      * @param args
      */
     public static void main(String[] args) {
-        final long seed = 0;
-        final boolean verbose = true;
+        System.out.println("Starting comparison...");
+
+        final long seed = System.currentTimeMillis();
+        final boolean verbose = false;
 
         // Heuristic
         final CloudSim simulation0 = new CloudSim();
@@ -138,6 +140,8 @@ public class DatacenterBrokersMappingComparison {
         final UniformDistr random2 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker2 = new DatacenterBrokerSimple(simulation2);
         new DatacenterBrokersMappingComparison(broker2, random2, verbose);
+
+        System.out.println("Comparison finished!");
     }
 
     /**
@@ -146,8 +150,6 @@ public class DatacenterBrokersMappingComparison {
     public DatacenterBrokersMappingComparison(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean verbose) {
         //Enables just some level of log messages.
         Log.setLevel(Level.ERROR);
-
-        System.out.println("Starting " + getClass().getSimpleName());
 
         broker = brkr;
         simulation = broker.getSimulation();
@@ -208,10 +210,8 @@ public class DatacenterBrokersMappingComparison {
 
 	private void print(final boolean verbose) {
         final double brokersMappingCost = computeBrokersMappingCost(verbose);
-        final double basicRoundRobinCost = computeRoundRobinMappingCost(verbose);
         System.out.printf(
-            "The solution based on %s mapper costs %.2f. Basic round robin implementation in this example costs %.2f.\n", broker.getClass().getSimpleName(), brokersMappingCost, basicRoundRobinCost);
-        System.out.println(getClass().getSimpleName() + " finished!");
+            "The solution based on %s mapper costs %.2f.\n", broker.getClass().getSimpleName(), brokersMappingCost);
 	}
 
 	/**
@@ -283,43 +283,24 @@ public class DatacenterBrokersMappingComparison {
                     .setUtilizationModel(utilization);
     }
 
-    private double computeRoundRobinMappingCost(boolean doPrint) {
-        CloudletToVmMappingSimulatedAnnealing heuristic =
-            new CloudletToVmMappingSimulatedAnnealing(SA_INITIAL_TEMPERATURE, random);
-        final CloudletToVmMappingSolution roundRobinSolution = new CloudletToVmMappingSolution(heuristic);
-        int i = 0;
-        for (Cloudlet c : cloudletList) {
-            //cyclically selects a Vm (as in a circular queue)
-            roundRobinSolution.bindCloudletToVm(c, vmList.get(i));
-            i = (i+1) % vmList.size();
-        }
-
-        if (doPrint) {
-            printSolution(
-                "Round robin solution used by DatacenterBrokerSimple class",
-                roundRobinSolution, false);
-        }
-        return roundRobinSolution.getCost();
-    }
-
     private double computeBrokersMappingCost(boolean doPrint) {
         CloudletToVmMappingSimulatedAnnealing heuristic =
             new CloudletToVmMappingSimulatedAnnealing(SA_INITIAL_TEMPERATURE, random);
 
-        final CloudletToVmMappingSolution bestFitSolution = new CloudletToVmMappingSolution(heuristic);
+        final CloudletToVmMappingSolution mappingSolution = new CloudletToVmMappingSolution(heuristic);
         int i = 0;
         for (Cloudlet c : cloudletList) {
             if (c.isBoundToVm()) {
-                bestFitSolution.bindCloudletToVm(c, c.getVm());
+                mappingSolution.bindCloudletToVm(c, c.getVm());
             }
         }
 
         if (doPrint) {
             printSolution(
                 "Best fit solution used by DatacenterBrokerSimple class",
-                bestFitSolution, false);
+                mappingSolution, false);
         }
-        return bestFitSolution.getCost();
+        return mappingSolution.getCost();
     }
 
     private void printSolution(

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -126,7 +126,7 @@ public class DatacenterBrokersMappingComparison {
 
         // Heuristic
         final CloudSim simulation0 = new CloudSim();
-        UniformDistr random0 = new UniformDistr(0, 1, seed);
+       final UniformDistr random0 = new UniformDistr(0, 1, seed);
         final DatacenterBrokerHeuristic broker0 = createHeuristicBroker(simulation0, random0);
         new DatacenterBrokersMappingComparison(broker0, random0, showTables);
 

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -77,7 +77,7 @@ import java.util.Map;
  * heuristic approach and round robin mapping.</p>
  *
  * @author Manoel Campos da Silva Filho
- * @since CloudSim Plus 1.0
+ * @since CloudSim Plus 4.3.8
  */
 public class DatacenterBrokersMappingComparison {
     private static final int HOSTS_TO_CREATE = 100;

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -132,7 +132,7 @@ public class DatacenterBrokersMappingComparison {
 
         // BestFit
         final CloudSim simulation1 = new CloudSim();
-        UniformDistr random1 = new UniformDistr(0, 1, seed);
+        final UniformDistr random1 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker1 = new DatacenterBrokerBestFit(simulation1);
         new DatacenterBrokersMappingComparison(broker1, random1, showTables);
 

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -79,7 +79,7 @@ import java.util.Map;
  * @author Manoel Campos da Silva Filho
  * @since CloudSim Plus 1.0
  */
-public class DatacenterBrokerHeuristicExample {
+public class DatacenterBrokersMappingComparison {
     private static final int HOSTS_TO_CREATE = 100;
     private static final int VMS_TO_CREATE = 50;
     private static final int CLOUDLETS_TO_CREATE = 100;
@@ -127,25 +127,25 @@ public class DatacenterBrokerHeuristicExample {
         final CloudSim simulation0 = new CloudSim();
         UniformDistr random0 = new UniformDistr(0, 1, seed);
         final DatacenterBrokerHeuristic broker0 = createHeuristicBroker(simulation0, random0);
-        new DatacenterBrokerHeuristicExample(broker0, random0, showTables);
+        new DatacenterBrokersMappingComparison(broker0, random0, showTables);
 
         // BestFit
         final CloudSim simulation1 = new CloudSim();
         UniformDistr random1 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker1 = new DatacenterBrokerBestFit(simulation1);
-        new DatacenterBrokerHeuristicExample(broker1, random1, showTables);
+        new DatacenterBrokersMappingComparison(broker1, random1, showTables);
 
         // Simple - RoundRobin
         final CloudSim simulation2 = new CloudSim();
         UniformDistr random2 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker2 = new DatacenterBrokerSimple(simulation2);
-        new DatacenterBrokerHeuristicExample(broker2, random2, showTables);
+        new DatacenterBrokersMappingComparison(broker2, random2, showTables);
     }
 
     /**
      * Default constructor where the simulation is built.
      */
-    public DatacenterBrokerHeuristicExample(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean showTables) {
+    public DatacenterBrokersMappingComparison(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean showTables) {
         //Enables just some level of log messages.
         Log.setLevel(Level.ERROR);
 

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -76,6 +76,7 @@ import java.util.Map;
  * <p>A comparison of cloudlet-VM mapping is done among the best fit approach,
  * heuristic approach and round robin mapping.</p>
  *
+ * @author Humaira Abdul Salam
  * @author Manoel Campos da Silva Filho
  * @since CloudSim Plus 4.3.8
  */

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -138,7 +138,7 @@ public class DatacenterBrokersMappingComparison {
 
         // Simple - RoundRobin
         final CloudSim simulation2 = new CloudSim();
-        UniformDistr random2 = new UniformDistr(0, 1, seed);
+        final UniformDistr random2 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker2 = new DatacenterBrokerSimple(simulation2);
         new DatacenterBrokersMappingComparison(broker2, random2, showTables);
     }

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -25,10 +25,7 @@ package org.cloudsimplus.examples.brokers;
 
 import ch.qos.logback.classic.Level;
 import org.cloudbus.cloudsim.allocationpolicies.VmAllocationPolicySimple;
-import org.cloudbus.cloudsim.brokers.DatacenterBroker;
-import org.cloudbus.cloudsim.brokers.DatacenterBrokerBestFit;
-import org.cloudbus.cloudsim.brokers.DatacenterBrokerHeuristic;
-import org.cloudbus.cloudsim.brokers.DatacenterBrokerSimple;
+import org.cloudbus.cloudsim.brokers.*;
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.cloudlets.CloudletSimple;
 import org.cloudbus.cloudsim.core.CloudSim;
@@ -122,31 +119,31 @@ public class DatacenterBrokersMappingComparison {
      */
     public static void main(String[] args) {
         final long seed = 0;
-        final boolean showTables = false;
+        final boolean verbose = true;
 
         // Heuristic
         final CloudSim simulation0 = new CloudSim();
-       final UniformDistr random0 = new UniformDistr(0, 1, seed);
+        final UniformDistr random0 = new UniformDistr(0, 1, seed);
         final DatacenterBrokerHeuristic broker0 = createHeuristicBroker(simulation0, random0);
-        new DatacenterBrokersMappingComparison(broker0, random0, showTables);
+        new DatacenterBrokersMappingComparison(broker0, random0, verbose);
 
         // BestFit
         final CloudSim simulation1 = new CloudSim();
         final UniformDistr random1 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker1 = new DatacenterBrokerBestFit(simulation1);
-        new DatacenterBrokersMappingComparison(broker1, random1, showTables);
+        new DatacenterBrokersMappingComparison(broker1, random1, verbose);
 
         // Simple - RoundRobin
         final CloudSim simulation2 = new CloudSim();
         final UniformDistr random2 = new UniformDistr(0, 1, seed);
         final DatacenterBroker broker2 = new DatacenterBrokerSimple(simulation2);
-        new DatacenterBrokersMappingComparison(broker2, random2, showTables);
+        new DatacenterBrokersMappingComparison(broker2, random2, verbose);
     }
 
     /**
      * Default constructor where the simulation is built.
      */
-    public DatacenterBrokersMappingComparison(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean showTables) {
+    public DatacenterBrokersMappingComparison(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean verbose) {
         //Enables just some level of log messages.
         Log.setLevel(Level.ERROR);
 
@@ -166,13 +163,13 @@ public class DatacenterBrokersMappingComparison {
         simulation.start();
 
         // print simulation results
-        if (showTables) {
+        if (verbose) {
             final List<Cloudlet> finishedCloudlets = broker.getCloudletFinishedList();
             finishedCloudlets.sort(Comparator.comparingLong(Cloudlet::getId));
             new CloudletsTableBuilder(finishedCloudlets).build();
         }
 
-        print();
+        print(verbose);
     }
 
     private static DatacenterBrokerHeuristic createHeuristicBroker(final CloudSim sim, final ContinuousDistribution rand) {
@@ -209,9 +206,9 @@ public class DatacenterBrokersMappingComparison {
 		return heuristic;
 	}
 
-	private void print() {
-        final double brokersMappingCost = computeBrokersMappingCost(false);
-        final double basicRoundRobinCost = computeRoundRobinMappingCost(false);
+	private void print(final boolean verbose) {
+        final double brokersMappingCost = computeBrokersMappingCost(verbose);
+        final double basicRoundRobinCost = computeRoundRobinMappingCost(verbose);
         System.out.printf(
             "The solution based on %s mapper costs %.2f. Basic round robin implementation in this example costs %.2f.\n", broker.getClass().getSimpleName(), brokersMappingCost, basicRoundRobinCost);
         System.out.println(getClass().getSimpleName() + " finished!");

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -153,7 +153,7 @@ public class DatacenterBrokersMappingComparison {
 
         this.broker = broker;
         simulation = broker.getSimulation();
-        random = rand;
+        this.random = random;
 
         final Datacenter datacenter = createDatacenter(simulation);
 

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -151,7 +151,7 @@ public class DatacenterBrokersMappingComparison {
         //Enables just some level of log messages.
         Log.setLevel(Level.ERROR);
 
-        broker = brkr;
+        this.broker = broker;
         simulation = broker.getSimulation();
         random = rand;
 

--- a/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/DatacenterBrokersMappingComparison.java
@@ -147,7 +147,7 @@ public class DatacenterBrokersMappingComparison {
     /**
      * Default constructor where the simulation is built.
      */
-    public DatacenterBrokersMappingComparison(final DatacenterBroker brkr, final ContinuousDistribution rand, final boolean verbose) {
+    public DatacenterBrokersMappingComparison(final DatacenterBroker broker, final ContinuousDistribution random, final boolean verbose) {
         //Enables just some level of log messages.
         Log.setLevel(Level.ERROR);
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -15,7 +15,6 @@ import org.cloudbus.cloudsim.datacenters.Datacenter;
 import org.cloudbus.cloudsim.schedulers.cloudlet.CloudletScheduler;
 import org.cloudbus.cloudsim.utilizationmodels.UtilizationModel;
 import org.cloudbus.cloudsim.vms.Vm;
-import org.cloudbus.cloudsim.vms.VmSimple;
 import org.cloudsimplus.autoscaling.VerticalVmScaling;
 import org.cloudsimplus.listeners.DatacenterBrokerEventInfo;
 import org.cloudsimplus.listeners.EventInfo;
@@ -700,7 +699,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
     private void processCloudletReturn(final SimEvent evt) {
         final Cloudlet cloudlet = (Cloudlet) evt.getData();
         cloudletsFinishedList.add(cloudlet);
-        ((VmSimple) cloudlet.getVm()).setExpectedFreePesNumber(
+        cloudlet.getVm().setExpectedFreePesNumber(
             cloudlet.getVm().getExpectedFreePesNumber() + cloudlet.getNumberOfPes());
         LOGGER.info("{}: {}: {} finished and returned to broker.", getSimulation().clock(), getName(), cloudlet);
 
@@ -922,7 +921,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
 
             //selects a VM for the given Cloudlet
             lastSelectedVm = vmMapper.apply(cloudlet);
-            ((VmSimple) lastSelectedVm).setExpectedFreePesNumber(
+            lastSelectedVm.setExpectedFreePesNumber(
                 lastSelectedVm.getExpectedFreePesNumber() - cloudlet.getNumberOfPes());
             if (lastSelectedVm == Vm.NULL) {
                 logPostponingCloudletExecution(cloudlet);

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -697,7 +697,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
      *
      * @param evt the cloudlet that has just finished to execute and was returned to the broker
      */
-    private void processCloudletReturn(final SimEvent evt) {
+    protected void processCloudletReturn(final SimEvent evt) {
         final Cloudlet cloudlet = (Cloudlet) evt.getData();
         cloudletsFinishedList.add(cloudlet);
         LOGGER.info("{}: {}: {} finished and returned to broker.", getSimulation().clock(), getName(), cloudlet);

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -15,6 +15,7 @@ import org.cloudbus.cloudsim.datacenters.Datacenter;
 import org.cloudbus.cloudsim.schedulers.cloudlet.CloudletScheduler;
 import org.cloudbus.cloudsim.utilizationmodels.UtilizationModel;
 import org.cloudbus.cloudsim.vms.Vm;
+import org.cloudbus.cloudsim.vms.VmSimple;
 import org.cloudsimplus.autoscaling.VerticalVmScaling;
 import org.cloudsimplus.listeners.DatacenterBrokerEventInfo;
 import org.cloudsimplus.listeners.EventInfo;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -697,9 +697,11 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
      *
      * @param evt a SimEvent object containing the cloudlet that has just finished executing and returned to the broker
      */
-    protected void processCloudletReturn(final SimEvent evt) {
+    private void processCloudletReturn(final SimEvent evt) {
         final Cloudlet cloudlet = (Cloudlet) evt.getData();
         cloudletsFinishedList.add(cloudlet);
+        cloudlet.getVm().setExpectedFreePesNumber(
+            cloudlet.getVm().getExpectedFreePesNumber() + cloudlet.getNumberOfPes());
         LOGGER.info("{}: {}: {} finished and returned to broker.", getSimulation().clock(), getName(), cloudlet);
 
         if (cloudlet.getVm().getCloudletScheduler().isEmpty()) {
@@ -920,6 +922,8 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
 
             //selects a VM for the given Cloudlet
             lastSelectedVm = vmMapper.apply(cloudlet);
+            lastSelectedVm.setExpectedFreePesNumber(
+                lastSelectedVm.getExpectedFreePesNumber() - cloudlet.getNumberOfPes());
             if (lastSelectedVm == Vm.NULL) {
                 logPostponingCloudletExecution(cloudlet);
                 continue;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -695,7 +695,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
     /**
      * Processes the end of execution of a given cloudlet inside a Vm.
      *
-     * @param evt the cloudlet that has just finished to execute and was returned to the broker
+     * @param evt a SimEvent object containing the cloudlet that has just finished executing and returned to the broker
      */
     protected void processCloudletReturn(final SimEvent evt) {
         final Cloudlet cloudlet = (Cloudlet) evt.getData();

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -922,12 +922,14 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
 
             //selects a VM for the given Cloudlet
             lastSelectedVm = vmMapper.apply(cloudlet);
-            ((VmSimple) lastSelectedVm).setExpectedFreePesNumber(
-                lastSelectedVm.getExpectedFreePesNumber() - cloudlet.getNumberOfPes());
             if (lastSelectedVm == Vm.NULL) {
                 logPostponingCloudletExecution(cloudlet);
                 continue;
+            } else {
+                ((VmSimple) lastSelectedVm).setExpectedFreePesNumber(
+                    lastSelectedVm.getExpectedFreePesNumber() - cloudlet.getNumberOfPes());
             }
+
 
             logCloudletCreationRequest(cloudlet);
             cloudlet.setVm(lastSelectedVm);

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerAbstract.java
@@ -700,7 +700,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
     private void processCloudletReturn(final SimEvent evt) {
         final Cloudlet cloudlet = (Cloudlet) evt.getData();
         cloudletsFinishedList.add(cloudlet);
-        cloudlet.getVm().setExpectedFreePesNumber(
+        ((VmSimple) cloudlet.getVm()).setExpectedFreePesNumber(
             cloudlet.getVm().getExpectedFreePesNumber() + cloudlet.getNumberOfPes());
         LOGGER.info("{}: {}: {} finished and returned to broker.", getSimulation().clock(), getName(), cloudlet);
 
@@ -922,7 +922,7 @@ public abstract class DatacenterBrokerAbstract extends CloudSimEntity implements
 
             //selects a VM for the given Cloudlet
             lastSelectedVm = vmMapper.apply(cloudlet);
-            lastSelectedVm.setExpectedFreePesNumber(
+            ((VmSimple) lastSelectedVm).setExpectedFreePesNumber(
                 lastSelectedVm.getExpectedFreePesNumber() - cloudlet.getNumberOfPes());
             if (lastSelectedVm == Vm.NULL) {
                 logPostponingCloudletExecution(cloudlet);

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -1,0 +1,107 @@
+package org.cloudbus.cloudsim.brokers;
+
+import org.cloudbus.cloudsim.cloudlets.Cloudlet;
+import org.cloudbus.cloudsim.core.CloudSim;
+import org.cloudbus.cloudsim.core.events.SimEvent;
+import org.cloudbus.cloudsim.vms.Vm;
+
+import javax.swing.text.html.Option;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+/**
+ * <p>A simple implementation of {@link DatacenterBroker} that uses a best fit
+ * mapping among submitted cloudlets and Vm's.
+ * The Broker then places the submitted Vm's at the first Datacenter found.
+ * If there isn't capacity in that one, it will try the other ones.</p>
+ *
+ * @author Humaira Abdul Salam
+ */
+public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
+
+    Map<Long, Long> vmNumberOfPesUpdated;
+    boolean firstVmMapperCall;
+
+    /**
+     * Creates a new DatacenterBroker object.
+     *
+     * @param simulation The CloudSim instance that represents the simulation the Entity is related to
+     */
+    public DatacenterBrokerBestFit(final CloudSim simulation) {
+        super(simulation);
+        setVmMapper(this::defaultVmMapper);
+        this.vmNumberOfPesUpdated = new HashMap<>();
+        firstVmMapperCall = true;
+    }
+
+    /**
+     * Processes the end of execution of a given cloudlet inside a Vm.
+     *
+     * @param evt the cloudlet that has just finished to execute and was returned to the broker
+     */
+    @Override
+    protected void processCloudletReturn(final SimEvent evt) {
+        for (Vm vm : getVmCreatedList())
+        {
+            updateNumberOfPes(vm.getId(), vm.getNumberOfPes());
+        }
+
+        super.processCloudletReturn(evt);
+    }
+    /**
+     * Selects the VM with the lowest number of PEs that is able to run a given Cloudlet.
+     * In case the algorithm can't find such a VM, it uses the
+     * default DatacenterBroker VM mapper as a fallback.
+     *
+     * @param cloudlet the Cloudlet to find a VM to run it
+     * @return the VM selected for the Cloudlet or {@link Vm#NULL} if no suitable VM was found
+     */
+    @Override
+    public Vm defaultVmMapper(final Cloudlet cloudlet) {
+        if (cloudlet.isBindToVm() && this.equals(cloudlet.getVm().getBroker()) && cloudlet.getVm().isCreated()) {
+            return cloudlet.getVm();
+        }
+
+        if (firstVmMapperCall)
+        {
+            for (Vm vm : getVmCreatedList())
+            {
+                updateNumberOfPes(vm.getId(), vm.getNumberOfPes());
+            }
+            firstVmMapperCall = false;
+        }
+
+        Optional<Map.Entry<Long, Long>> minVmPes = vmNumberOfPesUpdated
+                                                    .entrySet()
+                                                    .stream()
+                                                    .filter(x -> x.getValue() >= cloudlet.getNumberOfPes())
+                                                    .min(Comparator.comparingLong(x -> x.getValue()));
+
+        if (minVmPes.isPresent()) {
+            Vm mappedVm = getVmCreatedList()
+                .stream()
+                .filter(vm -> vm.getId() == minVmPes.get().getKey())
+                .findFirst()
+                .orElse(Vm.NULL);
+
+            if (mappedVm != Vm.NULL) {
+                LOGGER.debug("{} (PEs: {}) mapped to {} (available PEs: {})",
+                    cloudlet, cloudlet.getNumberOfPes(), mappedVm, vmNumberOfPesUpdated.get(mappedVm.getId()));
+                updateNumberOfPes(mappedVm.getId(), mappedVm.getNumberOfPes() - cloudlet.getNumberOfPes());
+            }
+            return mappedVm;
+        }
+        else
+        {
+            LOGGER.warn("{} (PEs: {}) couldn't be mapped to any VM",
+                cloudlet, cloudlet.getNumberOfPes());
+        }
+        return Vm.NULL;
+    }
+
+    private void updateNumberOfPes(final long vmId, final long availablePes)
+    {
+        vmNumberOfPesUpdated.put(vmId, availablePes);
+    }
+}

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -17,6 +17,7 @@ import java.util.stream.LongStream;
  * If there isn't capacity in that one, it will try the other ones.</p>
  *
  * @author Humaira Abdul Salam
+ * @since CloudSim Plus 4.3.8
  */
 public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
 
@@ -30,7 +31,6 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
      */
     public DatacenterBrokerBestFit(final CloudSim simulation) {
         super(simulation);
-        setVmMapper(this::defaultVmMapper);
         this.vmNumberOfPesUpdated = new HashMap<>();
         firstVmMapperCall = true;
     }
@@ -59,7 +59,7 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
      */
     @Override
     public Vm defaultVmMapper(final Cloudlet cloudlet) {
-        if (cloudlet.isBindToVm() && this.equals(cloudlet.getVm().getBroker()) && cloudlet.getVm().isCreated()) {
+        if (cloudlet.isBoundToCreatedVm()) {
             return cloudlet.getVm();
         }
 
@@ -86,7 +86,7 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
                 .orElse(Vm.NULL);
 
             if (mappedVm != Vm.NULL) {
-                LOGGER.debug("{} (PEs: {}) mapped to {} (available PEs: {})",
+                LOGGER.debug("{}: {}: {} (PEs: {}) mapped to {} (available PEs: {})", getSimulation().clock(), getName(),
                     cloudlet, cloudlet.getNumberOfPes(), mappedVm, vmNumberOfPesUpdated.get(mappedVm.getId()));
                 updateNumberOfPes(mappedVm.getId(), mappedVm.getNumberOfPes() - cloudlet.getNumberOfPes());
             }
@@ -94,8 +94,8 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
         }
         else
         {
-            LOGGER.warn("{} (PEs: {}) couldn't be mapped to any VM",
-                cloudlet, cloudlet.getNumberOfPes());
+            LOGGER.warn(": {}: {}: {} (PEs: {}) couldn't be mapped to any VM",
+                getSimulation().clock(), getName(), cloudlet, cloudlet.getNumberOfPes());
         }
         return Vm.NULL;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -65,7 +65,6 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
             LOGGER.debug("{}: {}: {} (PEs: {}) mapped to {} (available PEs: {}, tot PEs: {})",
                 getSimulation().clock(), getName(), cloudlet, cloudlet.getNumberOfPes(), mappedVm,
                 mappedVm.getExpectedFreePesNumber(), mappedVm.getFreePesNumber());
-            return mappedVm;
         }
         else
         {

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -71,7 +71,7 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
             LOGGER.warn(": {}: {}: {} (PEs: {}) couldn't be mapped to any VM",
                 getSimulation().clock(), getName(), cloudlet, cloudlet.getNumberOfPes());
         }
-        return Vm.NULL;
+        return mappedVm;
     }
 
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -57,7 +57,7 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
         final Vm mappedVm = getVmCreatedList()
             .stream()
             .filter(vm -> vm.getExpectedFreePesNumber() >= cloudlet.getNumberOfPes())
-            .min(Comparator.comparingLong(x -> x.getExpectedFreePesNumber()))
+            .min(Comparator.comparingLong(vm -> vm.getExpectedFreePesNumber()))
             .orElse(Vm.NULL);
 
         if(mappedVm != Vm.NULL){

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -54,7 +54,7 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
             return cloudlet.getVm();
         }
 
-        Vm mappedVm = getVmCreatedList()
+        final Vm mappedVm = getVmCreatedList()
             .stream()
             .filter(vm -> vm.getExpectedFreePesNumber() >= cloudlet.getNumberOfPes())
             .min(Comparator.comparingLong(x -> x.getExpectedFreePesNumber()))

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -2,7 +2,6 @@ package org.cloudbus.cloudsim.brokers;
 
 import org.cloudbus.cloudsim.cloudlets.Cloudlet;
 import org.cloudbus.cloudsim.core.CloudSim;
-import org.cloudbus.cloudsim.core.events.SimEvent;
 import org.cloudbus.cloudsim.vms.Vm;
 
 import java.util.*;
@@ -28,19 +27,6 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
     }
 
     /**
-     * Processes the end of execution of a given cloudlet inside a Vm.
-     *
-     * @param evt the cloudlet that has just finished to execute and was returned to the broker
-     */
-    @Override
-    protected void processCloudletReturn(final SimEvent evt) {
-        final Cloudlet cloudlet = (Cloudlet) evt.getData();
-        cloudlet.getVm().setExpectedFreePesNumber(
-            cloudlet.getVm().getExpectedFreePesNumber() + cloudlet.getNumberOfPes());
-        super.processCloudletReturn(evt);
-    }
-
-    /**
      * Selects the VM with the lowest number of PEs that is able to run a given Cloudlet.
      * In case the algorithm can't find such a VM, it uses the
      * default DatacenterBroker VM mapper as a fallback.
@@ -61,7 +47,6 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
             .orElse(Vm.NULL);
 
         if(mappedVm != Vm.NULL){
-            mappedVm.setExpectedFreePesNumber(mappedVm.getExpectedFreePesNumber()-cloudlet.getNumberOfPes());
             LOGGER.debug("{}: {}: {} (PEs: {}) mapped to {} (available PEs: {}, tot PEs: {})",
                 getSimulation().clock(), getName(), cloudlet, cloudlet.getNumberOfPes(), mappedVm,
                 mappedVm.getExpectedFreePesNumber(), mappedVm.getFreePesNumber());

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerBestFit.java
@@ -56,7 +56,7 @@ public class DatacenterBrokerBestFit extends DatacenterBrokerSimple {
 
         Vm mappedVm = getVmCreatedList()
             .stream()
-            .filter(x -> x.getExpectedFreePesNumber() >= cloudlet.getNumberOfPes())
+            .filter(vm -> vm.getExpectedFreePesNumber() >= cloudlet.getNumberOfPes())
             .min(Comparator.comparingLong(x -> x.getExpectedFreePesNumber()))
             .orElse(Vm.NULL);
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerHeuristic.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerHeuristic.java
@@ -50,7 +50,7 @@ public class DatacenterBrokerHeuristic extends DatacenterBrokerSimple {
         heuristic.setVmList(getVmExecList());
         heuristic.setCloudletList(
 	        getCloudletWaitingList().stream()
-                        .filter(cloudlet -> !cloudlet.isBindToVm())
+                        .filter(cloudlet -> !cloudlet.isBoundToVm())
                         .collect(Collectors.toList()));
         /*
         Starts the heuristic to get a sub-optimal solution

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/brokers/DatacenterBrokerSimple.java
@@ -88,13 +88,8 @@ public class DatacenterBrokerSimple extends DatacenterBrokerAbstract {
      */
     @Override
     public Vm defaultVmMapper(final Cloudlet cloudlet) {
-        if (cloudlet.isBindToVm()) {
-            final Vm vm = cloudlet.getVm();
-            if(this.equals(vm.getBroker()) && vm.isCreated()) {
-                return vm;
-            }
-
-            return Vm.NULL;
+        if (cloudlet.isBoundToCreatedVm()) {
+            return cloudlet.getVm();
         }
 
         /*If user didn't bind this cloudlet to a specific Vm

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/Cloudlet.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/Cloudlet.java
@@ -493,7 +493,15 @@ public interface Cloudlet extends UniquelyIdentifiable, Comparable<Cloudlet>, Cu
      *
      * @return true if the Cloudlet is bounded to a specific VM, false otherwise
      */
-    boolean isBindToVm();
+    boolean isBoundToVm();
+
+    /**
+     * Check if the Cloudlet is bound to any Vm and if so then check
+     * if the Vm is already created
+     *
+     * @return true if the Cloudlet is bound to a created VM, false otherwise
+     */
+    boolean isBoundToCreatedVm();
 
     /**
      * Gets the time the cloudlet had to wait before start executing on a

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/Cloudlet.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/Cloudlet.java
@@ -497,7 +497,6 @@ public interface Cloudlet extends UniquelyIdentifiable, Comparable<Cloudlet>, Cu
 
     /**
      * Checks if the Cloudlet is bound to any Vm and if that Vm is already created.
-     * if the Vm is already created
      *
      * @return true if the Cloudlet is bound to a created VM, false otherwise
      */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/Cloudlet.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/Cloudlet.java
@@ -496,7 +496,7 @@ public interface Cloudlet extends UniquelyIdentifiable, Comparable<Cloudlet>, Cu
     boolean isBoundToVm();
 
     /**
-     * Check if the Cloudlet is bound to any Vm and if so then check
+     * Checks if the Cloudlet is bound to any Vm and if that Vm is already created.
      * if the Vm is already created
      *
      * @return true if the Cloudlet is bound to a created VM, false otherwise

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/CloudletAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/CloudletAbstract.java
@@ -813,7 +813,7 @@ public abstract class CloudletAbstract extends CustomerEntityAbstract implements
 
     @Override
     public boolean isBoundToCreatedVm(){
-        return isBoundToVm() && this.getBroker().equals(this.getVm().getBroker()) && this.getVm().isCreated();
+        return isBoundToVm() && this.getVm().isCreated() && this.getBroker().equals(this.getVm().getBroker());
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/CloudletAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/CloudletAbstract.java
@@ -807,8 +807,13 @@ public abstract class CloudletAbstract extends CustomerEntityAbstract implements
     }
 
     @Override
-    public boolean isBindToVm() {
+    public boolean isBoundToVm() {
         return vm != null && vm != Vm.NULL;
+    }
+
+    @Override
+    public boolean isBoundToCreatedVm(){
+        return isBoundToVm() && this.getBroker().equals(this.getVm().getBroker()) && this.getVm().isCreated();
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/CloudletNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/CloudletNull.java
@@ -194,9 +194,8 @@ final class CloudletNull implements Cloudlet {
         return 0;
     }
     @Override public void setSubmissionDelay(double submissionDelay) {/**/}
-    @Override public boolean isBindToVm() {
-        return false;
-    }
+    @Override public boolean isBoundToVm() { return false; }
+    @Override public boolean isBoundToCreatedVm() { return false; }
     @Override public int compareTo(Cloudlet cloudlet) {
         return 0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletSendTask.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/cloudlets/network/CloudletSendTask.java
@@ -65,10 +65,10 @@ public class CloudletSendTask extends CloudletTask {
         if(getCloudlet() == null) {
             throw new IllegalStateException("You must assign a NetworkCloudlet to this Task before adding packets.");
         }
-        if(!getCloudlet().isBindToVm()) {
+        if(!getCloudlet().isBoundToVm()) {
             throw new IllegalStateException("The source Cloudlet has to have an assigned VM.");
         }
-        if(!destinationCloudlet.isBindToVm()) {
+        if(!destinationCloudlet.isBoundToVm()) {
             throw new IllegalStateException("The destination Cloudlet has to have an assigned VM.");
         }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -21,6 +21,7 @@ import org.cloudbus.cloudsim.schedulers.cloudlet.network.CloudletTaskScheduler;
 import org.cloudbus.cloudsim.util.Conversion;
 import org.cloudbus.cloudsim.utilizationmodels.UtilizationModel;
 import org.cloudbus.cloudsim.vms.Vm;
+import org.cloudbus.cloudsim.vms.VmSimple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -528,15 +529,17 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
     @SuppressWarnings("ForLoopReplaceableByForEach")
     private double updateCloudletsProcessing(final double currentTime) {
         double nextCloudletFinishTime = Double.MAX_VALUE;
+        long usedPes = 0;
         /* Uses an indexed for to avoid ConcurrentModificationException,
          * e.g., in cases when Cloudlet is cancelled during simulation execution. */
         for (int i = 0; i < cloudletExecList.size(); i++) {
             final CloudletExecution cle = cloudletExecList.get(i);
             updateCloudletProcessingAndPacketsDispatch(cle, currentTime);
             nextCloudletFinishTime = Math.min(nextCloudletFinishTime, cloudletEstimatedFinishTime(cle, currentTime));
-            cle.getCloudlet().getVm().setFreePesNumber(
-                cle.getCloudlet().getVm().getFreePesNumber() - cle.getCloudlet().getNumberOfPes());
+            usedPes += cle.getCloudlet().getNumberOfPes();
         }
+
+        ((VmSimple) vm).setFreePesNumber(vm.getFreePesNumber() - usedPes);
 
         return nextCloudletFinishTime;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -534,6 +534,8 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
             final CloudletExecution cle = cloudletExecList.get(i);
             updateCloudletProcessingAndPacketsDispatch(cle, currentTime);
             nextCloudletFinishTime = Math.min(nextCloudletFinishTime, cloudletEstimatedFinishTime(cle, currentTime));
+            cle.getCloudlet().getVm().setFreePesNumber(
+                cle.getCloudlet().getVm().getFreePesNumber() - cle.getCloudlet().getNumberOfPes());
         }
 
         return nextCloudletFinishTime;
@@ -998,7 +1000,7 @@ public abstract class CloudletSchedulerAbstract implements CloudletScheduler {
 
     /**
      * Gets a <b>read-only</b> list of Cloudlets that finished executing and were returned the their broker.
-     * A Cloudlet is returned to to notify the broker about the end of its execution.
+     * A Cloudlet is returned to notify the broker about the end of its execution.
      * @return
      */
     protected Set<Cloudlet> getCloudletReturnedList() {

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -21,6 +21,8 @@ import org.cloudsimplus.autoscaling.VerticalVmScaling;
 import org.cloudsimplus.listeners.EventListener;
 import org.cloudsimplus.listeners.VmDatacenterEventInfo;
 import org.cloudsimplus.listeners.VmHostEventInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.function.Predicate;
@@ -39,6 +41,7 @@ import java.util.function.Predicate;
  * @since CloudSim Plus 1.0
  */
 public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, CustomerEntity {
+    Logger LOGGER = LoggerFactory.getLogger(Vm.class.getSimpleName());
 
     /**
      * An attribute that implements the Null Object Design Pattern for {@link Vm}

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -77,6 +77,35 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     CloudletScheduler getCloudletScheduler();
 
     /**
+     * Gets the free pes number.
+     *
+     * @return the free pes number
+     */
+    long getFreePesNumber();
+
+    /**
+     * Sets the free pes number.
+     *
+     * @return the new free pes number
+     */
+    Vm setFreePesNumber(long freePes);
+
+
+    /**
+     * Gets the expected free pes number. This will be updated when cloudlets will be assigned to VMs but not submitted to the broker yet for running.
+     *
+     * @return the expected free pes number
+     */
+    long getExpectedFreePesNumber();
+
+    /**
+     * Gets the expected free pes number. This will be updated when cloudlets will be assigned to VMs but not submitted to the broker yet for running.
+     *
+     * @return the expected free pes number
+     */
+    Vm setExpectedFreePesNumber(long expFreePes);
+
+    /**
      * Gets the current requested bw.
      *
      * @return the current requested bw

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -87,26 +87,11 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     long getFreePesNumber();
 
     /**
-     * Sets the current number of free PEs.
-     *
-     * @return the new free pes number
-     */
-    Vm setFreePesNumber(long freePes);
-
-
-    /**
      * Gets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *
      * @return the expected free pes number
      */
     long getExpectedFreePesNumber();
-
-    /**
-     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
-     *
-     * @param expectedFreePes the expected free pes number to set
-     */
-    Vm setExpectedFreePesNumber(long expectedFreePes);
 
     /**
      * Gets the current requested bw.

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -95,7 +95,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
 
 
     /**
-     * Gets the expected free pes number. This will be updated when cloudlets will be assigned to VMs but not submitted to the broker yet for running.
+     * Gets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *
      * @return the expected free pes number
      */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -80,7 +80,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     CloudletScheduler getCloudletScheduler();
 
     /**
-     * Gets the free pes number.
+     * Gets the current number of free PEs.
      *
      * @return the free pes number
      */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -82,7 +82,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     /**
      * Gets the current number of free PEs.
      *
-     * @return the free pes number
+     * @return the current free pes number
      */
     long getFreePesNumber();
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -87,7 +87,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     long getFreePesNumber();
 
     /**
-     * Sets the free pes number.
+     * Sets the current number of free PEs.
      *
      * @return the new free pes number
      */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -93,7 +93,6 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
      */
     Vm setFreePesNumber(long freePes);
 
-
     /**
      * Gets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -87,25 +87,11 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     long getFreePesNumber();
 
     /**
-     * Sets the current number of free PEs.
-     *
-     * @return the new free pes number
-     */
-    Vm setFreePesNumber(long freePes);
-
-    /**
      * Gets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *
      * @return the expected free pes number
      */
     long getExpectedFreePesNumber();
-
-    /**
-     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
-     *
-     * @param expectedFreePes the expected free pes number to set
-     */
-    Vm setExpectedFreePesNumber(long expectedFreePes);
 
     /**
      * Gets the current requested bw.

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -87,11 +87,26 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     long getFreePesNumber();
 
     /**
+     * Sets the current number of free PEs.
+     *
+     * @return the new free pes number
+     */
+    Vm setFreePesNumber(long freePes);
+
+
+    /**
      * Gets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *
      * @return the expected free pes number
      */
     long getExpectedFreePesNumber();
+
+    /**
+     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
+     *
+     * @param expectedFreePes the expected free pes number to set
+     */
+    Vm setExpectedFreePesNumber(long expectedFreePes);
 
     /**
      * Gets the current requested bw.

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -104,7 +104,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     /**
      * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *
-     * @return the expected free pes number
+     * @param expectedFreePes the expected free pes number to set
      */
     Vm setExpectedFreePesNumber(long expFreePes);
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -102,7 +102,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
     long getExpectedFreePesNumber();
 
     /**
-     * Gets the expected free pes number. This will be updated when cloudlets will be assigned to VMs but not submitted to the broker yet for running.
+     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
      *
      * @return the expected free pes number
      */

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/Vm.java
@@ -106,7 +106,7 @@ public interface Vm extends Machine, UniquelyIdentifiable, Comparable<Vm>, Custo
      *
      * @param expectedFreePes the expected free pes number to set
      */
-    Vm setExpectedFreePesNumber(long expFreePes);
+    Vm setExpectedFreePesNumber(long expectedFreePes);
 
     /**
      * Gets the current requested bw.

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
@@ -40,9 +40,7 @@ final class VmNull implements Vm {
     }
     @Override public CloudletScheduler getCloudletScheduler() { return CloudletScheduler.NULL; }
     @Override public long getFreePesNumber() { return 0; }
-    @Override public Vm setFreePesNumber(long freePes) { return this; }
     @Override public long getExpectedFreePesNumber() { return 0; }
-    @Override public Vm setExpectedFreePesNumber(long expFreePes) { return this; }
     @Override public long getCurrentRequestedBw() {
         return 0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
@@ -39,6 +39,10 @@ final class VmNull implements Vm {
         return Resource.NULL;
     }
     @Override public CloudletScheduler getCloudletScheduler() { return CloudletScheduler.NULL; }
+    @Override public long getFreePesNumber() { return 0; }
+    @Override public Vm setFreePesNumber(long freePes) { return this; }
+    @Override public long getExpectedFreePesNumber() { return 0; }
+    @Override public Vm setExpectedFreePesNumber(long expFreePes) { return this; }
     @Override public long getCurrentRequestedBw() {
         return 0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmNull.java
@@ -40,7 +40,9 @@ final class VmNull implements Vm {
     }
     @Override public CloudletScheduler getCloudletScheduler() { return CloudletScheduler.NULL; }
     @Override public long getFreePesNumber() { return 0; }
+    @Override public Vm setFreePesNumber(long freePes) { return this; }
     @Override public long getExpectedFreePesNumber() { return 0; }
+    @Override public Vm setExpectedFreePesNumber(long expFreePes) { return this; }
     @Override public long getCurrentRequestedBw() {
         return 0;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -287,18 +287,13 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         return freePesNumber;
     }
 
-
-    /**
-     * Sets the current number of free PEs.
-     *
-     * @return the new free pes number
-     */
-    public Vm setFreePesNumber(long freePesNumber) {
-        if(freePesNumber < 0) {
-            LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
-            freePesNumber = 0;
+    @Override
+    public Vm setFreePesNumber(long freePes) {
+        if(freePes < 0) {
+            LOGGER.warn("Number of free PEs cannot be negative.");
+            freePes = 0;
         }
-        this.freePesNumber = Math.min(freePesNumber, getNumberOfPes());
+        freePesNumber = Math.min(freePes, getNumberOfPes());
         return this;
     }
 
@@ -307,15 +302,11 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         return expectedFreePesNumber;
     }
 
-    /**
-     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
-     *
-     * @param expectedFreePes the expected free pes number to set
-     */
+    @Override
     public Vm setExpectedFreePesNumber(long expectedFreePes) {
-        if(expectedFreePes < 0) {
-            LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
-            expectedFreePes = 0;
+        if(expFreePes < 0) {
+            LOGGER.warn("Number of free PEs cannot be negative.");
+            expFreePes = 0;
         }
         this.expectedFreePesNumber = expectedFreePes;
         return this;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -289,8 +289,9 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
 
     @Override
     public Vm setFreePesNumber(long freePes) {
-        if(freePes < 0){
-            throw new IllegalArgumentException("Number of free PEs cannot be negative.");
+        if(freePes < 0) {
+            LOGGER.warn("Number of free PEs cannot be negative.");
+            freePes = 0;
         }
         freePesNumber = Math.min(freePes, getNumberOfPes());
         return this;
@@ -303,8 +304,9 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
 
     @Override
     public Vm setExpectedFreePesNumber(long expFreePes) {
-        if(expFreePes < 0){
-            throw new IllegalArgumentException("Number of free PEs cannot be negative.");
+        if(expFreePes < 0) {
+            LOGGER.warn("Number of free PEs cannot be negative.");
+            expFreePes = 0;
         }
         expectedFreePesNumber = expFreePes;
         return this;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -303,7 +303,7 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
     }
 
     @Override
-    public Vm setExpectedFreePesNumber(long expFreePes) {
+    public Vm setExpectedFreePesNumber(long expectedFreePes) {
         if(expFreePes < 0) {
             LOGGER.warn("Number of free PEs cannot be negative.");
             expFreePes = 0;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -287,7 +287,11 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         return freePesNumber;
     }
 
-    @Override
+    /**
+     * Sets the current number of free PEs.
+     *
+     * @return the new free pes number
+     */
     public Vm setFreePesNumber(long freePesNumber) {
         if(freePesNumber < 0) {
             LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
@@ -302,7 +306,11 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         return expectedFreePesNumber;
     }
 
-    @Override
+    /**
+     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
+     *
+     * @param expectedFreePes the expected free pes number to set
+     */
     public Vm setExpectedFreePesNumber(long expectedFreePes) {
         if(expectedFreePes < 0) {
             LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -308,7 +308,7 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
             LOGGER.warn("Number of free PEs cannot be negative.");
             expFreePes = 0;
         }
-        expectedFreePesNumber = expFreePes;
+        this.expectedFreePesNumber = expectedFreePes;
         return this;
     }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -116,6 +116,12 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
      */
     private Bandwidth bw;
 
+    /** @see #getFreePesNumber() */
+    private long freePesNumber;
+
+    /** @see #getFreePesNumber() */
+    private long expectedFreePesNumber;
+
     /**
      * @see #getSubmissionDelay()
      */
@@ -240,6 +246,10 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
 
         //By default, the VM doesn't store utilization history. This has to be enabled by the user as wanted
         utilizationHistory = new VmUtilizationHistory(this, false);
+
+        //initiate number of free PEs as number of PEs of VM
+        freePesNumber = numberOfPes;
+        expectedFreePesNumber = numberOfPes;
     }
 
     @Override
@@ -270,6 +280,34 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         utilizationHistory.addUtilizationHistory(currentTime);
         ((DatacenterBrokerAbstract)getBroker()).requestIdleVmDestruction(this);
         return nextEventDelay - decimals;
+    }
+
+    @Override
+    public long getFreePesNumber() {
+        return freePesNumber;
+    }
+
+    @Override
+    public Vm setFreePesNumber(long freePes) {
+        if(freePes < 0){
+            throw new IllegalArgumentException("Number of free PEs cannot be negative.");
+        }
+        freePesNumber = Math.min(freePes, getNumberOfPes());
+        return this;
+    }
+
+    @Override
+    public long getExpectedFreePesNumber() {
+        return expectedFreePesNumber;
+    }
+
+    @Override
+    public Vm setExpectedFreePesNumber(long expFreePes) {
+        if(expFreePes < 0){
+            throw new IllegalArgumentException("Number of free PEs cannot be negative.");
+        }
+        expectedFreePesNumber = expFreePes;
+        return this;
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -287,13 +287,18 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         return freePesNumber;
     }
 
-    @Override
-    public Vm setFreePesNumber(long freePes) {
-        if(freePes < 0) {
-            LOGGER.warn("Number of free PEs cannot be negative.");
-            freePes = 0;
+
+    /**
+     * Sets the current number of free PEs.
+     *
+     * @return the new free pes number
+     */
+    public Vm setFreePesNumber(long freePesNumber) {
+        if(freePesNumber < 0) {
+            LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
+            freePesNumber = 0;
         }
-        freePesNumber = Math.min(freePes, getNumberOfPes());
+        this.freePesNumber = Math.min(freePesNumber, getNumberOfPes());
         return this;
     }
 
@@ -302,11 +307,15 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
         return expectedFreePesNumber;
     }
 
-    @Override
+    /**
+     * Sets the expected free pes number before the VM starts executing. This value is updated as cloudlets are assigned to VMs but not submitted to the broker yet for running.
+     *
+     * @param expectedFreePes the expected free pes number to set
+     */
     public Vm setExpectedFreePesNumber(long expectedFreePes) {
-        if(expFreePes < 0) {
-            LOGGER.warn("Number of free PEs cannot be negative.");
-            expFreePes = 0;
+        if(expectedFreePes < 0) {
+            LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
+            expectedFreePes = 0;
         }
         this.expectedFreePesNumber = expectedFreePes;
         return this;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/vms/VmSimple.java
@@ -288,12 +288,12 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
     }
 
     @Override
-    public Vm setFreePesNumber(long freePes) {
-        if(freePes < 0) {
-            LOGGER.warn("Number of free PEs cannot be negative.");
-            freePes = 0;
+    public Vm setFreePesNumber(long freePesNumber) {
+        if(freePesNumber < 0) {
+            LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
+            freePesNumber = 0;
         }
-        freePesNumber = Math.min(freePes, getNumberOfPes());
+        this.freePesNumber = Math.min(freePesNumber, getNumberOfPes());
         return this;
     }
 
@@ -304,9 +304,9 @@ public class VmSimple extends CustomerEntityAbstract implements Vm {
 
     @Override
     public Vm setExpectedFreePesNumber(long expectedFreePes) {
-        if(expFreePes < 0) {
-            LOGGER.warn("Number of free PEs cannot be negative.");
-            expFreePes = 0;
+        if(expectedFreePes < 0) {
+            LOGGER.debug("Number of free PEs cannot be negative, resetting to zero.");
+            expectedFreePes = 0;
         }
         this.expectedFreePesNumber = expectedFreePes;
         return this;

--- a/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/HeuristicSolution.java
+++ b/cloudsim-plus/src/main/java/org/cloudsimplus/heuristics/HeuristicSolution.java
@@ -23,6 +23,9 @@
  */
 package org.cloudsimplus.heuristics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A solution for a complex problem found using a {@link Heuristic} implementation.
  * A heuristic can generate multiple solutions until find an optimal or suboptimal
@@ -34,6 +37,8 @@ package org.cloudsimplus.heuristics;
  * @since CloudSim Plus 1.0
  */
 public interface HeuristicSolution<T> extends Comparable<HeuristicSolution<T>> {
+    Logger LOGGER = LoggerFactory.getLogger(HeuristicSolution.class.getSimpleName());
+
     /**
      * An attribute that implements the Null Object Design Pattern for {@link HeuristicSolution}
      * objects.

--- a/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/cloudlets/CloudletTest.java
+++ b/cloudsim-plus/src/test/java/org/cloudbus/cloudsim/cloudlets/CloudletTest.java
@@ -20,13 +20,13 @@ public class CloudletTest {
     @Test
     public void testIsBoundedToVm() {
         final Cloudlet cloudlet = createCloudlet(0);
-        assertFalse(cloudlet.isBindToVm());
+        assertFalse(cloudlet.isBoundToVm());
         cloudlet.setVm(Vm.NULL);
-        assertFalse(cloudlet.isBindToVm());
+        assertFalse(cloudlet.isBoundToVm());
         cloudlet.setVm(VmTestUtil.createVm(0, 1));
-        assertTrue(cloudlet.isBindToVm());
+        assertTrue(cloudlet.isBoundToVm());
         cloudlet.setVm(VmTestUtil.createVm(1, 1));
-        assertTrue(cloudlet.isBindToVm());
+        assertTrue(cloudlet.isBoundToVm());
     }
 
     private static CloudletSimple createCloudlet(int id) {
@@ -57,7 +57,7 @@ public class CloudletTest {
         EasyMock.replay(listener);
         Cloudlet.NULL.addOnFinishListener(listener);
 
-        assertFalse(Cloudlet.NULL.isBindToVm());
+        assertFalse(Cloudlet.NULL.isBoundToVm());
     }
 
     @Test


### PR DESCRIPTION
This PR adds `DatacenterBrokerBestFit`, another implementation of `DatacenterBroker` with a best fit cloudlet-VM mapper (best fit in a truer sense ;) ). This is different from the approach in [`bestFitCloudletToVmMapper()`](https://github.com/humaira-salam/cloudsim-plus/blob/d0ff7dbda7f5e6d641e78bfe5c84f99205c508a6/cloudsim-plus-examples/src/main/java/org/cloudsimplus/examples/brokers/CloudletToVmMappingBestFit.java#L130
) (in example: `CloudletToVmMappingBestFit`), because the `DatacenterBroker` maps a `Cloudlet` to a `Vm` without checking if the `Pe`s in the `Vm` are already being reserved by other `Cloudlet`s. This is easily reproducible with the case when number of `Cloudlet`s are more than `Vm`s. Also, the inherent behavior of java `Stream`'s `min()` method causes the same `Vm` to be selected over-and-over when multiple `Vm`s have the same number of `Pe`s. 

The example `DatacenterBrokerHeuristicExample` is also updated to compare the Heuristic based mapping with the BestFit based mapping. Both BestFit approaches can be compared by toggling the parameter `useBestFitBroker` in the example. The new BestFit approach's mapping cost is consistently lower by more than half the round-robin based mapping cost, however, the approach from the example `CloudletToVmMappingBestFit` costs around twice more than the round-robin approach.
