### PR TITLE
Introduce sync execution of the simulation

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -37,7 +37,7 @@ public class CloudSim implements Simulation {
     /**
      * CloudSim Plus current version.
      */
-    public static final String VERSION = "CloudSim Plus 4.5.1";
+    public static final String VERSION = "CloudSim Plus 4.5.0";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudSim.class.getSimpleName());
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -476,7 +476,7 @@ public class CloudSim implements Simulation {
         return runClockTickAndProcessFutureEvents(Double.MAX_VALUE);
     }
 
-    private boolean runClockTickAndProcessFutureEvents(double until) {
+    private boolean runClockTickAndProcessFutureEvents(final double until) {
         executeRunnableEntities(until);
         if (future.isEmpty()) {
             return false;
@@ -548,7 +548,7 @@ public class CloudSim implements Simulation {
      * Gets the list of entities that are in {@link SimEntity.State#RUNNABLE}
      * and execute them.
      */
-    private void executeRunnableEntities(double until) {
+    private void executeRunnableEntities(final double until) {
         /*Uses an indexed for instead of anything else to avoid
         ConcurrencyModificationException when a HostFaultInjection is created inside a Datacenter*/
         for (int i = 0; i < entities.size(); i++) {

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -37,7 +37,7 @@ public class CloudSim implements Simulation {
     /**
      * CloudSim Plus current version.
      */
-    public static final String VERSION = "CloudSim Plus 4.4.2";
+    public static final String VERSION = "CloudSim Plus 4.5.1";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudSim.class.getSimpleName());
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSimEntity.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSimEntity.java
@@ -289,19 +289,6 @@ public abstract class CloudSimEntity implements SimEntity {
         return getNextEvent(Simulation.ANY_EVT);
     }
 
-    public SimEvent getNextEventUntil(double until) {
-        return getNextEvent(anyUntil(until));
-    }
-
-    private Predicate<SimEvent> anyUntil(double until) {
-        return new Predicate<SimEvent>() {
-            @Override
-            public boolean test(SimEvent simEvent) {
-                return simEvent.getTime() <= until;
-            }
-        };
-    }
-
     /**
      * Waits for an event matching a specific predicate. This method does not
      * check the entity's deferred queue.
@@ -319,22 +306,11 @@ public abstract class CloudSimEntity implements SimEntity {
 
     @Override
     public void run() {
-        SimEvent evt = buffer == null ? getNextEvent() : buffer;
-
-        while (evt != SimEvent.NULL) {
-            processEvent(evt);
-            if (state != State.RUNNABLE) {
-                break;
-            }
-
-            evt = getNextEvent();
-        }
-
-        buffer = null;
+        run(Double.MAX_VALUE);
     }
 
-    public void runUntil(double until) {
-        SimEvent evt = buffer == null ? getNextEventUntil(until) : buffer;
+    public void run(final double until) {
+        SimEvent evt = buffer == null ? getNextEvent(e -> e.getTime() <= until) : buffer;
 
         while (evt != SimEvent.NULL) {
             processEvent(evt);
@@ -342,7 +318,7 @@ public abstract class CloudSimEntity implements SimEntity {
                 break;
             }
 
-            evt = getNextEventUntil(until);
+            evt = getNextEvent(e -> e.getTime() <= until);
         }
 
         buffer = null;

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSimEntity.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSimEntity.java
@@ -289,6 +289,19 @@ public abstract class CloudSimEntity implements SimEntity {
         return getNextEvent(Simulation.ANY_EVT);
     }
 
+    public SimEvent getNextEventUntil(double until) {
+        return getNextEvent(anyUntil(until));
+    }
+
+    private Predicate<SimEvent> anyUntil(double until) {
+        return new Predicate<SimEvent>() {
+            @Override
+            public boolean test(SimEvent simEvent) {
+                return simEvent.getTime() <= until;
+            }
+        };
+    }
+
     /**
      * Waits for an event matching a specific predicate. This method does not
      * check the entity's deferred queue.
@@ -315,6 +328,21 @@ public abstract class CloudSimEntity implements SimEntity {
             }
 
             evt = getNextEvent();
+        }
+
+        buffer = null;
+    }
+
+    public void runUntil(double until) {
+        SimEvent evt = buffer == null ? getNextEventUntil(until) : buffer;
+
+        while (evt != SimEvent.NULL) {
+            processEvent(evt);
+            if (state != State.RUNNABLE) {
+                break;
+            }
+
+            evt = getNextEventUntil(until);
         }
 
         buffer = null;
@@ -541,5 +569,4 @@ public abstract class CloudSimEntity implements SimEntity {
         result = 31 * result + Long.hashCode(id);
         return result;
     }
-
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/Simulation.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/Simulation.java
@@ -317,6 +317,23 @@ public interface Simulation {
     void sendNow(SimEntity src, SimEntity dest, int tag, Object data);
 
     /**
+     * Finalizes the simulation and cleans up internal state.
+     *
+     * <b>Note:</b> Should be used only in the <b>synchronous</b> mode (after starting the simulation
+     * with <b>startSync</b>).
+     */
+    void finishSimulation();
+
+    /**
+     * Runs the simulation for a specific period of time and then immediately returns.
+     * In order to complete the whole simulation you need to invoke this method multiple times
+     *
+     * @param interval The interval for which the simulation should be run
+     * @return Clock at the end of simulation interval
+     */
+    double runFor(double interval);
+
+    /**
      * Starts simulation execution and <b>waits for
      * all entities to finish</b>, i.e. until all entities threads reach
      * non-RUNNABLE state or there are no more events in the future event queue.
@@ -331,6 +348,22 @@ public interface Simulation {
      * you must use {@link #resume()} instead of calling the current method.
      */
     double start();
+
+    /**
+     * Starts simulation execution. Simulation is being run in synchronous mode - you need
+     * to call <b>runFor</b> method subsequently to actually process simulation steps. Requires
+     * finalizing the simulation with use of the <b>finishSimulation</b> method.
+     *
+     * <b>Note</b>: This method should be called just after all the entities
+     * have been setup and added. The method returns immediately after preparing the
+     * internal state of the simulation.
+     * </p>
+     *
+     * @throws UnsupportedOperationException When the simulation has already run once.
+     * If you paused the simulation and wants to resume it,
+     * you must use {@link #resume()} instead of calling the current method.
+     */
+    void startSync();
 
     boolean isTimeToTerminateSimulationUnderRequest();
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/Simulation.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/Simulation.java
@@ -320,7 +320,7 @@ public interface Simulation {
      * Finalizes the simulation and cleans up internal state.
      *
      * <b>Note:</b> Should be used only in the <b>synchronous</b> mode (after starting the simulation
-     * with <b>startSync</b>).
+     * with {@link #startSync()}).
      */
     void finishSimulation();
 
@@ -328,8 +328,11 @@ public interface Simulation {
      * Runs the simulation for a specific period of time and then immediately returns.
      * In order to complete the whole simulation you need to invoke this method multiple times
      *
-     * @param interval The interval for which the simulation should be run
-     * @return Clock at the end of simulation interval
+     * <b>Note:</b> Should be used only in the <b>synchronous</b> mode (after starting the simulation
+     * with {@link #startSync()}).
+     *
+     * @param interval The interval for which the simulation should be run (in seconds)
+     * @return Clock at the end of simulation interval (in seconds)
      */
     double runFor(double interval);
 
@@ -346,13 +349,15 @@ public interface Simulation {
      * @throws UnsupportedOperationException When the simulation has already run once.
      * If you paused the simulation and wants to resume it,
      * you must use {@link #resume()} instead of calling the current method.
+     *
+     * @see #startSync()
      */
     double start();
 
     /**
-     * Starts simulation execution. Simulation is being run in synchronous mode - you need
-     * to call <b>runFor</b> method subsequently to actually process simulation steps. Requires
-     * finalizing the simulation with use of the <b>finishSimulation</b> method.
+     * Starts simulation execution in synchronous mode - you need
+     * to call {@link #runFor(double)} method subsequently to actually process simulation steps. Requires
+     * finalizing the simulation with use of the {@link #finishSimulation()} method.
      *
      * <b>Note</b>: This method should be called just after all the entities
      * have been setup and added. The method returns immediately after preparing the
@@ -362,6 +367,9 @@ public interface Simulation {
      * @throws UnsupportedOperationException When the simulation has already run once.
      * If you paused the simulation and wants to resume it,
      * you must use {@link #resume()} instead of calling the current method.
+     *
+     * @see #runFor(double)
+     * @see #finishSimulation()
      */
     void startSync();
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/SimulationNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/SimulationNull.java
@@ -76,6 +76,8 @@ final class SimulationNull implements Simulation {
     @Override public void sendFirst(SimEvent evt) {/**/}
     @Override public void sendFirst(SimEntity src, SimEntity dest, double delay, int tag, Object data) {/**/}
     @Override public void sendNow(SimEntity src, SimEntity dest, int tag, Object data) {/**/}
+    @Override public void finishSimulation() { /**/ }
+    @Override public double runFor(double interval) { return 0; }
     @Override public Simulation addOnEventProcessingListener(EventListener<SimEvent> listener) {
         return this;
     }
@@ -86,6 +88,7 @@ final class SimulationNull implements Simulation {
         return false;
     }
     @Override public double start() throws RuntimeException { return 0; }
+    @Override public void startSync() { /**/ }
     @Override public boolean isTimeToTerminateSimulationUnderRequest() { return false; }
     @Override public boolean terminate() {
         return false;

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <!-- License file to be used by the com.mycila.license-maven-plugin -->
         <copyrightfile>COPYRIGHT</copyrightfile>
         <!-- Version used by all submodules which is managed by the flatten-maven-plugin -->
-        <global.version>4.4.2</global.version>
+        <global.version>4.5.1</global.version>
     </properties>
 
     <groupId>org.cloudsimplus</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
         <!-- License file to be used by the com.mycila.license-maven-plugin -->
         <copyrightfile>COPYRIGHT</copyrightfile>
         <!-- Version used by all submodules which is managed by the flatten-maven-plugin -->
-        <global.version>4.5.1</global.version>
+        <global.version>4.5.0</global.version>
     </properties>
 
     <groupId>org.cloudsimplus</groupId>


### PR DESCRIPTION
#### What's this Pull Request does, clear and precisely?

The purpose is to introduce synchronous control over execution of the simulation (being able to set the simulation in the "running" state and then move it forward step by step as needed).

#### Where should the reviewer start?

Most of the changes are in the `CloudSim` class. You can start at `startSync`, `finalizeSimulation` and `runFor` and it should get your through all additional methods.

#### Are there some simulation examples to show the performed changes working?

I can provide some if you want to go in this direction.

#### What are the relevant issue ticket numbers?

https://github.com/manoelcampos/cloudsim-plus/issues/205


#### The issues or features included were discussed elsewhere outside github? If yes, please provide the links.

#### Any additional information you want to provide?

Nope - just let me know what you think. If this is a direction you are interested in merging let me know what should I add/change to get it to a "merge-able" state.