### PR TITLE
Fix the sample function for the PoissonDistr

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/distributions/PoissonDistr.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/distributions/PoissonDistr.java
@@ -172,7 +172,7 @@ public class PoissonDistr implements ContinuousDistribution {
      */
     @Override
     public double sample() {
-        return Math.exp(1.0 - rand.sample()) / getLambda();
+        return -Math.log(1.0 - rand.sample()) / getLambda();
     }
 
     @Override


### PR DESCRIPTION
The [sample](https://github.com/manoelcampos/cloudsim-plus/blob/ae7da17cf08012a9ac31564cb59f4a1fe62af5b9/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/distributions/PoissonDistr.java#L175) function for the PoissonDistr doesn't implement the "inverse transform sampling" correctly. 

This PR fixes the sampling according to Eq. 2.40 from the reference: "Ralf Korn, Elke Korn, et al. 1st edition, 2010. Section 2.4.1: Exponential distribution. Page 33."

