### PR TITLE
Fixes README's section 5  minimal simulation scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,13 +266,13 @@ vm0.setRam(1000).setBw(1000).setSize(1000);
 vmList.add(vm0);
 
 //Creates Cloudlets that represent applications to be run inside a VM.
-List<Cloudlet> cloudletList = new ArrayList<>(1);
+List<Cloudlet> cloudletList = new ArrayList<>();
 //UtilizationModel defining the Cloudlets use only 50% of any resource all the time
 UtilizationModelDynamic utilizationModel = new UtilizationModelDynamic(0.5);
 Cloudlet cloudlet0 = new CloudletSimple(10000, 1, utilizationModel);
 Cloudlet cloudlet1 = new CloudletSimple(10000, 1, utilizationModel);
-cloudlets.add(cloudlet0);
-cloudlets.add(cloudlet1);
+cloudletList.add(cloudlet0);
+cloudletList.add(cloudlet1);
 
 broker0.submitVmList(vmList);
 broker0.submitCloudletList(cloudletList);


### PR DESCRIPTION
This PR fixes a minor error that exists in README's 5th section that gives Java code for a minimal simulation scenario. 

As seen here:

```java
//Creates Cloudlets that represent applications to be run inside a VM.
List<Cloudlet> cloudletList = new ArrayList<>(1);
//UtilizationModel defining the Cloudlets use only 50% of any resource all the time
UtilizationModelDynamic utilizationModel = new UtilizationModelDynamic(0.5);
Cloudlet cloudlet0 = new CloudletSimple(10000, 1, utilizationModel);
Cloudlet cloudlet1 = new CloudletSimple(10000, 1, utilizationModel);
cloudlets.add(cloudlet0);
cloudlets.add(cloudlet1);
```

`cloudletList` is mispelled in add operations as `cloudlets` resulting in a compilation error.
