### PR TITLE
Migrating network API from id-based to object-based

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample1.java
@@ -98,11 +98,11 @@ public class NetworkExample1 {
         //maps CloudSim entities to BRITE entities
         //Datacenter will correspond to BRITE node 0
         int briteNode = 0;
-        networkTopology.mapNode(datacenter0.getId(), briteNode);
+        networkTopology.mapNode(datacenter0, briteNode);
 
         //Broker will correspond to BRITE node 3
         briteNode = 3;
-        networkTopology.mapNode(broker.getId(), briteNode);
+        networkTopology.mapNode(broker, briteNode);
     }
 
     private void createAndSubmitCloudlets(DatacenterBroker broker) {

--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample2.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample2.java
@@ -91,15 +91,15 @@ public class NetworkExample2 {
         //Maps CloudSim entities to BRITE entities
         //Datacenter0 will correspond to BRITE node 0
         int briteNode = 0;
-        networkTopology.mapNode(datacenterList.get(0).getId(), briteNode);
+        networkTopology.mapNode(datacenterList.get(0), briteNode);
 
         //Datacenter1 will correspond to BRITE node 2
         briteNode = 2;
-        networkTopology.mapNode(datacenterList.get(1).getId(), briteNode);
+        networkTopology.mapNode(datacenterList.get(1), briteNode);
 
         //Broker will correspond to BRITE node 3
         briteNode = 3;
-        networkTopology.mapNode(broker.getId(), briteNode);
+        networkTopology.mapNode(broker, briteNode);
     }
 
     private void createAndSubmitCloudlets() {

--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample3.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample3.java
@@ -155,19 +155,19 @@ public class NetworkExample3 {
         //Maps CloudSim entities to BRITE entities
         //Datacenter0 will correspond to BRITE node 0
         int briteNode = 0;
-        networkTopology.mapNode(datacenterList.get(0).getId(), briteNode);
+        networkTopology.mapNode(datacenterList.get(0), briteNode);
 
         //Datacenter1 will correspond to BRITE node 2
         briteNode = 2;
-        networkTopology.mapNode(datacenterList.get(1).getId(), briteNode);
+        networkTopology.mapNode(datacenterList.get(1), briteNode);
 
         //Broker1 will correspond to BRITE node 3
         briteNode = 3;
-        networkTopology.mapNode(brokerList.get(0).getId(), briteNode);
+        networkTopology.mapNode(brokerList.get(0), briteNode);
 
         //Broker2 will correspond to BRITE node 4
         briteNode = 4;
-        networkTopology.mapNode(brokerList.get(1).getId(), briteNode);
+        networkTopology.mapNode(brokerList.get(1), briteNode);
     }
 
     private Datacenter createDatacenter() {

--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample4.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample4.java
@@ -85,7 +85,7 @@ public class NetworkExample4 {
         //Configure network by mapping CloudSim entities to BRITE entities
         NetworkTopology networkTopology = new BriteNetworkTopology();
         simulation.setNetworkTopology(networkTopology);
-        networkTopology.addLink(datacenter0.getId(), broker.getId(), 10.0, 10);
+        networkTopology.addLink(datacenter0, broker, 10.0, 10);
     }
 
     private void createAndSubmitCloudlets() {

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSimEntity.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSimEntity.java
@@ -449,7 +449,7 @@ public abstract class CloudSimEntity implements SimEntity {
 
         // only considers network delay when sending messages between different entities
         if (dest.getId() != getId()) {
-            delay += getNetworkDelay(getId(), dest.getId());
+            delay += getNetworkDelay(this, dest);
         }
 
         schedule(dest, delay, cloudSimTag, data);
@@ -502,7 +502,7 @@ public abstract class CloudSimEntity implements SimEntity {
      * @param dst destination of the message
      * @return delay to send a message from src to dst
      */
-    private double getNetworkDelay(final long src, final long dst) {
+    private double getNetworkDelay(final SimEntity src, final SimEntity dst) {
         return getSimulation().getNetworkTopology().getDelay(src, dst);
     }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/BriteNetworkTopology.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/BriteNetworkTopology.java
@@ -7,6 +7,7 @@
  */
 package org.cloudbus.cloudsim.network.topologies;
 
+import org.cloudbus.cloudsim.core.SimEntity;
 import org.cloudbus.cloudsim.network.DelayMatrix;
 import org.cloudbus.cloudsim.network.topologies.readers.TopologyReaderBrite;
 import org.cloudbus.cloudsim.util.ResourceLoader;
@@ -65,7 +66,7 @@ public final class BriteNetworkTopology implements NetworkTopology {
      * The entitiesMap between CloudSim entities and BRITE entities.
      * Each key is a CloudSim entity ID and each value the corresponding BRITE entity ID.
      */
-    private Map<Long, Integer> entitiesMap;
+    private Map<SimEntity, Integer> entitiesMap;
 
     /**
      * Instantiates a Network Topology from a file inside the <b>application's resource directory</b>.
@@ -168,7 +169,7 @@ public final class BriteNetworkTopology implements NetworkTopology {
 
 
     @Override
-    public void addLink(final long srcId, final long destId, final double bandwidth, final double latency) {
+    public void addLink(final SimEntity src, final SimEntity dest, final double bandwidth, final double latency) {
         if (getTopologicalGraph() == null) {
             graph = new TopologicalGraph();
         }
@@ -178,30 +179,30 @@ public final class BriteNetworkTopology implements NetworkTopology {
         }
 
         // maybe add the nodes
-        addNodeMapping(srcId);
-        addNodeMapping(destId);
+        addNodeMapping(src);
+        addNodeMapping(dest);
 
         // generate a new link
-        getTopologicalGraph().addLink(new TopologicalLink(entitiesMap.get(srcId), entitiesMap.get(destId), (float) latency, (float) bandwidth));
+        getTopologicalGraph().addLink(new TopologicalLink(entitiesMap.get(src), entitiesMap.get(dest), (float) latency, (float) bandwidth));
 
         generateMatrices();
     }
 
-    private void addNodeMapping(final long cloudSimEntityId) {
-        if (entitiesMap.putIfAbsent(cloudSimEntityId, nextIdx) == null) {
+    private void addNodeMapping(final SimEntity entity) {
+        if (entitiesMap.putIfAbsent(entity, nextIdx) == null) {
             getTopologicalGraph().addNode(new TopologicalNode(nextIdx));
             nextIdx++;
         }
     }
 
     @Override
-    public void mapNode(final long cloudSimEntityID, final int briteID) {
+    public void mapNode(final SimEntity entity, final int briteID) {
         if (!networkEnabled) {
             return;
         }
 
-        if (entitiesMap.containsKey(cloudSimEntityID)) {
-            LOGGER.warn("Network mapping: CloudSim entity {} already mapped.", cloudSimEntityID);
+        if (entitiesMap.containsKey(entity)) {
+            LOGGER.warn("Network mapping: CloudSim entity {} already mapped.", entity);
             return;
         }
 
@@ -210,26 +211,26 @@ public final class BriteNetworkTopology implements NetworkTopology {
             return;
         }
 
-        entitiesMap.put(cloudSimEntityID, briteID);
+        entitiesMap.put(entity, briteID);
     }
 
     @Override
-    public void unmapNode(final long cloudSimEntityID) {
+    public void unmapNode(final SimEntity entity) {
         if (!networkEnabled) {
             return;
         }
 
-        entitiesMap.remove(cloudSimEntityID);
+        entitiesMap.remove(entity);
     }
 
     @Override
-    public double getDelay(final long srcID, final long destID) {
+    public double getDelay(final SimEntity src, final SimEntity dest) {
         if (!networkEnabled) {
             return 0.0;
         }
 
         try {
-            return delayMatrix.getDelay(entitiesMap.getOrDefault(srcID, -1), entitiesMap.getOrDefault(destID, -1));
+            return delayMatrix.getDelay(entitiesMap.getOrDefault(src, -1), entitiesMap.getOrDefault(dest, -1));
         } catch (ArrayIndexOutOfBoundsException e) {
             return 0.0;
         }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopology.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopology.java
@@ -7,6 +7,8 @@
  */
 package org.cloudbus.cloudsim.network.topologies;
 
+import org.cloudbus.cloudsim.core.SimEntity;
+
 /**
  **
  * Implements a network layer by reading the topology from a file in a specific format
@@ -30,44 +32,40 @@ public interface NetworkTopology {
      * Adds a new link in the network topology. The CloudSim entities that
      * represent the source and destination of the link will be mapped to BRITE
      * entities.
-     *  @param srcId ID of the CloudSim entity that represents the link's source
+     *  @param src CloudSim entity that represents the link's source
      * node
-     * @param destId ID of the CloudSim entity that represents the link's
+     * @param dest CloudSim entity that represents the link's
      * destination node
      * @param bw Link's bandwidth
      * @param lat link's latency
-     * @TODO It should receive entities instead of IDs
      */
-    void addLink(long srcId, long destId, double bw, double lat);
+    void addLink(SimEntity src, SimEntity dest, double bw, double lat);
 
     /**
      * Maps a CloudSim entity to a BRITE node in the network topology.
-     * @param cloudSimEntityID ID of the entity being mapped
+     * @param entity CloudSim entity being mapped
      * @param briteID ID of the BRITE node that corresponds to the CloudSim
-     * @TODO It should receive an CloudSim entity instead of an ID
      */
-    void mapNode(long cloudSimEntityID, int briteID);
+    void mapNode(SimEntity entity, int briteID);
 
     /**
      * Un-maps a previously mapped CloudSim entity to a BRITE node in the network
      * topology.
      *
-     * @param cloudSimEntityID ID of the entity being unmapped
-     * @TODO It should receive an CloudSim entity instead of an ID
+     * @param entity CloudSim entity being unmapped
      */
-    void unmapNode(long cloudSimEntityID);
+    void unmapNode(SimEntity entity);
 
     /**
      * Calculates the delay between two nodes.
      *
-     * @param srcID ID of the CloudSim entity that represents the link's source
+     * @param src CloudSim entity that represents the link's source
      * node
-     * @param destID ID of the CloudSim entity that represents the link's
+     * @param dest CloudSim entity that represents the link's
      * destination node
      * @return communication delay between the two nodes
-     * @TODO It should receive entities instead of IDs
      */
-    double getDelay(long srcID, long destID);
+    double getDelay(SimEntity src, SimEntity dest);
 
     /**
      * Checks if the network simulation is working. If there were some problem

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopologyNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopologyNull.java
@@ -1,5 +1,7 @@
 package org.cloudbus.cloudsim.network.topologies;
 
+import org.cloudbus.cloudsim.core.SimEntity;
+
 /**
  * A class that implements the Null Object Design Pattern for {@link NetworkTopology}
  * class.
@@ -10,10 +12,10 @@ package org.cloudbus.cloudsim.network.topologies;
 final class NetworkTopologyNull implements NetworkTopology {
     private static final TopologicalGraph GRAPH = new TopologicalGraph();
 
-    @Override public void addLink(long srcId, long destId, double bandwidth, double lat) {/**/}
-    @Override public void mapNode(long cloudSimEntityID, int briteID) {/**/}
-    @Override public void unmapNode(long cloudSimEntityID) {/**/}
-    @Override public double getDelay(long srcID, long destID) {
+    @Override public void addLink(SimEntity src, SimEntity dest, double bandwidth, double lat) {/**/}
+    @Override public void mapNode(SimEntity entity, int briteID) {/**/}
+    @Override public void unmapNode(SimEntity entity) {/**/}
+    @Override public double getDelay(SimEntity src, SimEntity dest) {
         return 0;
     }
     @Override public boolean isNetworkEnabled() {


### PR DESCRIPTION
First step towards refactoring the network API (#261).
So far it was based on the IDs of SimEntitys, now users can pass the SimEntitys directly.