### PR TITLE
Removed Brite-specific methods from NetworkTopology interface

### DIFF
--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample1.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample1.java
@@ -92,7 +92,7 @@ public class NetworkExample1 {
 
     private void configureNetwork() {
         //load the network topology file
-        NetworkTopology networkTopology = BriteNetworkTopology.getInstance(NETWORK_TOPOLOGY_FILE);
+        BriteNetworkTopology networkTopology = BriteNetworkTopology.getInstance(NETWORK_TOPOLOGY_FILE);
         simulation.setNetworkTopology(networkTopology);
 
         //maps CloudSim entities to BRITE entities

--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample2.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample2.java
@@ -85,7 +85,7 @@ public class NetworkExample2 {
 
     private void configureNetwork() {
         //Configures network by loading the network topology file
-        NetworkTopology networkTopology = BriteNetworkTopology.getInstance(NETWORK_TOPOLOGY_FILE);
+        BriteNetworkTopology networkTopology = BriteNetworkTopology.getInstance(NETWORK_TOPOLOGY_FILE);
         simulation.setNetworkTopology(networkTopology);
 
         //Maps CloudSim entities to BRITE entities

--- a/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample3.java
+++ b/cloudsim-plus-examples/src/main/java/org/cloudbus/cloudsim/examples/network/NetworkExample3.java
@@ -149,7 +149,7 @@ public class NetworkExample3 {
      */
     private void createNetwork() {
         //load the network topology file
-        NetworkTopology networkTopology = BriteNetworkTopology.getInstance("topology.brite");
+        BriteNetworkTopology networkTopology = BriteNetworkTopology.getInstance("topology.brite");
         simulation.setNetworkTopology(networkTopology);
 
         //Maps CloudSim entities to BRITE entities

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/BriteNetworkTopology.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/BriteNetworkTopology.java
@@ -58,7 +58,7 @@ public final class BriteNetworkTopology implements NetworkTopology {
     private double[][] bwMatrix;
 
     /**
-     * The Topological Graph of the network.
+     * @see #getTopologicalGraph()
      */
     private TopologicalGraph graph;
 
@@ -199,6 +199,11 @@ public final class BriteNetworkTopology implements NetworkTopology {
         }
     }
 
+    /**
+     * Maps a CloudSim entity to a BRITE node in the network topology.
+     * @param entity CloudSim entity being mapped
+     * @param briteID ID of the BRITE node that corresponds to the CloudSim
+     */
     public void mapNode(final SimEntity entity, final int briteID) {
         if (!networkEnabled) {
             return;
@@ -217,6 +222,12 @@ public final class BriteNetworkTopology implements NetworkTopology {
         entitiesMap.put(entity, briteID);
     }
 
+    /**
+     * Un-maps a previously mapped CloudSim entity to a BRITE node in the network
+     * topology.
+     *
+     * @param entity CloudSim entity being unmapped
+     */
     public void unmapNode(final SimEntity entity) {
         if (!networkEnabled) {
             return;
@@ -238,10 +249,21 @@ public final class BriteNetworkTopology implements NetworkTopology {
         }
     }
 
+    /**
+     * Checks if the network simulation is working. If there were some problem
+     * during creation of network (e.g., during parsing of BRITE file) that does
+     * not allow a proper simulation of the network, this method returns false.
+     *
+     * @return $true if network simulation is working, $false otherwise
+     */
     public boolean isNetworkEnabled() {
         return networkEnabled;
     }
 
+    /**
+     * Gets the Topological Graph of the network.
+     * @return
+     */
     public TopologicalGraph getTopologicalGraph() {
         return graph;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/BriteNetworkTopology.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/BriteNetworkTopology.java
@@ -167,7 +167,6 @@ public final class BriteNetworkTopology implements NetworkTopology {
         return mtx;
     }
 
-
     @Override
     public void addLink(final SimEntity src, final SimEntity dest, final double bandwidth, final double latency) {
         if (getTopologicalGraph() == null) {
@@ -188,6 +187,11 @@ public final class BriteNetworkTopology implements NetworkTopology {
         generateMatrices();
     }
 
+    @Override
+    public void removeLink(SimEntity src, SimEntity dest) {
+        throw new UnsupportedOperationException("Removing links is not yet supported on BriteNetworkTopologies");
+    }
+
     private void addNodeMapping(final SimEntity entity) {
         if (entitiesMap.putIfAbsent(entity, nextIdx) == null) {
             getTopologicalGraph().addNode(new TopologicalNode(nextIdx));
@@ -195,7 +199,6 @@ public final class BriteNetworkTopology implements NetworkTopology {
         }
     }
 
-    @Override
     public void mapNode(final SimEntity entity, final int briteID) {
         if (!networkEnabled) {
             return;
@@ -214,7 +217,6 @@ public final class BriteNetworkTopology implements NetworkTopology {
         entitiesMap.put(entity, briteID);
     }
 
-    @Override
     public void unmapNode(final SimEntity entity) {
         if (!networkEnabled) {
             return;
@@ -236,12 +238,10 @@ public final class BriteNetworkTopology implements NetworkTopology {
         }
     }
 
-    @Override
     public boolean isNetworkEnabled() {
         return networkEnabled;
     }
 
-    @Override
     public TopologicalGraph getTopologicalGraph() {
         return graph;
     }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopology.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopology.java
@@ -18,7 +18,6 @@ import org.cloudbus.cloudsim.core.SimEntity;
  * @author Anton Beloglazov
  * @author Manoel Campos da Silva Filho
  *
- * @see BriteNetworkTopology
  * @since CloudSim Plus 1.0
  */
 public interface NetworkTopology {
@@ -41,20 +40,7 @@ public interface NetworkTopology {
      */
     void addLink(SimEntity src, SimEntity dest, double bw, double lat);
 
-    /**
-     * Maps a CloudSim entity to a BRITE node in the network topology.
-     * @param entity CloudSim entity being mapped
-     * @param briteID ID of the BRITE node that corresponds to the CloudSim
-     */
-    void mapNode(SimEntity entity, int briteID);
-
-    /**
-     * Un-maps a previously mapped CloudSim entity to a BRITE node in the network
-     * topology.
-     *
-     * @param entity CloudSim entity being unmapped
-     */
-    void unmapNode(SimEntity entity);
+    void removeLink(SimEntity src, SimEntity dest);
 
     /**
      * Calculates the delay between two nodes.
@@ -67,17 +53,4 @@ public interface NetworkTopology {
      */
     double getDelay(SimEntity src, SimEntity dest);
 
-    /**
-     * Checks if the network simulation is working. If there were some problem
-     * during creation of network (e.g., during parsing of BRITE file) that does
-     * not allow a proper simulation of the network, this method returns false.
-     *
-     * @return $true if network simulation is working, $false otherwise
-     */
-    boolean isNetworkEnabled();
-
-    /**
-     * @return the graph
-     */
-    TopologicalGraph getTopologicalGraph();
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopologyNull.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/network/topologies/NetworkTopologyNull.java
@@ -13,13 +13,8 @@ final class NetworkTopologyNull implements NetworkTopology {
     private static final TopologicalGraph GRAPH = new TopologicalGraph();
 
     @Override public void addLink(SimEntity src, SimEntity dest, double bandwidth, double lat) {/**/}
-    @Override public void mapNode(SimEntity entity, int briteID) {/**/}
-    @Override public void unmapNode(SimEntity entity) {/**/}
+    @Override public void removeLink(SimEntity src, SimEntity dest) {/**/}
     @Override public double getDelay(SimEntity src, SimEntity dest) {
         return 0;
     }
-    @Override public boolean isNetworkEnabled() {
-        return false;
-    }
-    @Override public TopologicalGraph getTopologicalGraph() { return GRAPH; }
 }


### PR DESCRIPTION
The NetworkTopology interface contained several methods that were specific to Brite topologies.
On the other hand, a removeLink() method was missing.