### PR TITLE
PowerMeasurement fields don't need to be validated

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeasurement.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeasurement.java
@@ -27,29 +27,8 @@ public class PowerMeasurement {
      * @param dynamicUsage power (in watts) the entity consumes according to its load
      */
     public PowerMeasurement(final double staticUsage, final double dynamicUsage) {
-        this.staticUsage = validatePower(staticUsage, "staticPower");
-        this.dynamicUsage = validatePower(dynamicUsage, "maxPower");
-    }
-
-    /**
-     * Checks if a power value (in Watts) is valid.
-     * @param power the value to validate
-     * @param fieldName the name of the field/variable storing the value
-     * @return the given power if it's valid
-     * @throws IllegalArgumentException when the value is smaller than 1
-     */
-    public static double validatePower(final double power, final String fieldName) {
-        if (power < 0) {
-            throw new IllegalArgumentException(fieldName+" cannot be negative");
-        }
-
-        if(power < 1){
-            throw new IllegalArgumentException(
-                fieldName +
-                " must be in watts. A value smaller than 1 may indicate you're trying to give a percentage value instead.");
-        }
-
-        return power;
+        this.staticUsage = staticUsage;
+        this.dynamicUsage = dynamicUsage;
     }
 
     /**

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeasurement.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeasurement.java
@@ -15,20 +15,20 @@ import java.util.Objects;
  */
 public class PowerMeasurement {
 
-    /** @see #getStaticUsage() */
-    private double staticUsage;
+    /** @see #getStaticPower() */
+    private double staticPower;
 
-    /** @see #getDynamicUsage() */
-    private double dynamicUsage;
+    /** @see #getDynamicPower() */
+    private double dynamicPower;
 
     /**
      * Instantiates a power measurement with a given static and dynamic power consumption.
-     * @param staticUsage power (in watts) the entity consumes when idle
-     * @param dynamicUsage power (in watts) the entity consumes according to its load
+     * @param staticPower power (in watts) the entity consumes when idle
+     * @param dynamicPower power (in watts) the entity consumes according to its load
      */
-    public PowerMeasurement(final double staticUsage, final double dynamicUsage) {
-        this.staticUsage = staticUsage;
-        this.dynamicUsage = dynamicUsage;
+    public PowerMeasurement(final double staticPower, final double dynamicPower) {
+        this.staticPower = staticPower;
+        this.dynamicPower = dynamicPower;
     }
 
     /**
@@ -42,24 +42,24 @@ public class PowerMeasurement {
      * Gets the total power consumed by the entity (in Watts)
      * @return
      */
-    public double getTotalUsage() {
-        return staticUsage + dynamicUsage;
+    public double getTotalPower() {
+        return staticPower + dynamicPower;
     }
 
     /**
      * Gets the static power the entity consumes even if it's idle (in Watts).
      * @return
      */
-    public double getStaticUsage() {
-        return staticUsage;
+    public double getStaticPower() {
+        return staticPower;
     }
 
     /**
      * Gets the dynamic power the entity consumes according to its load (in Watts).
      * @return
      */
-    public double getDynamicUsage() {
-        return dynamicUsage;
+    public double getDynamicPower() {
+        return dynamicPower;
     }
 
     /**
@@ -71,8 +71,8 @@ public class PowerMeasurement {
     public PowerMeasurement add(final PowerMeasurement measurement) {
         Objects.requireNonNull(measurement, "measurement cannot be null");
         return new PowerMeasurement(
-            staticUsage + measurement.getStaticUsage(),
-            dynamicUsage + measurement.getDynamicUsage()
+            staticPower + measurement.getStaticPower(),
+            dynamicPower + measurement.getDynamicPower()
         );
     }
 
@@ -84,8 +84,8 @@ public class PowerMeasurement {
      */
     public PowerMeasurement multiply(final double factor) {
         return new PowerMeasurement(
-            staticUsage * factor,
-            dynamicUsage * factor
+            staticPower * factor,
+            dynamicPower * factor
         );
     }
 }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModel.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModel.java
@@ -25,7 +25,7 @@ public interface PowerModel {
      * representing the Watts consumed.
      */
     default double getPower() {
-        return getPowerMeasurement().getTotalUsage();
+        return getPowerMeasurement().getTotalPower();
     }
 }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelHostSimple.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/models/PowerModelHostSimple.java
@@ -2,8 +2,6 @@ package org.cloudbus.cloudsim.power.models;
 
 import org.cloudbus.cloudsim.power.PowerMeasurement;
 
-import static org.cloudbus.cloudsim.power.PowerMeasurement.validatePower;
-
 /**
  * Simple power model for hosts with linear power profile.
  * @since CloudSim Plus 6.0.0
@@ -52,6 +50,27 @@ public class PowerModelHostSimple extends PowerModelHost {
         }
 
         return staticPower + (maxPower - staticPower) * utilizationFraction;
+    }
+
+    /**
+     * Checks if a power value (in Watts) is valid.
+     * @param power the value to validate
+     * @param fieldName the name of the field/variable storing the value
+     * @return the given power if it's valid
+     * @throws IllegalArgumentException when the value is smaller than 1
+     */
+    private static double validatePower(final double power, final String fieldName) {
+        if (power < 0) {
+            throw new IllegalArgumentException(fieldName+" cannot be negative");
+        }
+
+        if(power < 1){
+            throw new IllegalArgumentException(
+                fieldName +
+                    " must be in watts. A value smaller than 1 may indicate you're trying to give a percentage value instead.");
+        }
+
+        return power;
     }
 
 }


### PR DESCRIPTION
The PowerMeasurement constructor is not to be confused with the validation taking place in PowerModels where the fields are "maxPower" and "staticPower" (where "staticPower" can be ambiguous).
In PowerMeasurement we have two absolute values "staticUsage" and "dynamicUsage", that are also expected to be valid when they are between 0 and 1.