### PR TITLE
avoid ConcurrentModificationException in event loop

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -561,13 +561,11 @@ public class CloudSim implements Simulation {
         processEvent(firstEvent);
         future.remove(firstEvent);
 
-        //Uses iterator to increase efficiency and avoid ConcurrentModificationException while removing
-        for(final Iterator<SimEvent> it = future.iterator(); it.hasNext();){
-            SimEvent evt = it.next();
-            if(evt.getTime() == firstEvent.getTime()){
-                processEvent(evt);
-                it.remove();
-            }
+        while(!future.isEmpty()) {
+            SimEvent evt = future.first();
+            if(evt.getTime() != firstEvent.getTime()) break;
+            processEvent(evt);
+            future.remove(evt);
         }
     }
 

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/core/CloudSim.java
@@ -562,8 +562,9 @@ public class CloudSim implements Simulation {
         future.remove(firstEvent);
 
         while(!future.isEmpty()) {
-            SimEvent evt = future.first();
-            if(evt.getTime() != firstEvent.getTime()) break;
+            final SimEvent evt = future.first();
+            if(evt.getTime() != firstEvent.getTime())
+                break;
             processEvent(evt);
             future.remove(evt);
         }


### PR DESCRIPTION
When working with many concurrent events the previous solution was regularly throwing `ConcurrentModificationException`s.
The new implementation is simpler and just walks the future event queue until the time on an event is not equal to the time of the first event.