### PR TITLE
Bugfix: PowerMeter was re-scheduling events indefinitely

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeter.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeter.java
@@ -106,11 +106,11 @@ public class PowerMeter extends CloudSimEntity {
         powerMeasurements.add(measurement);
     }
 
+    /**
+     * Just re-schedule measurements if there are other events to be processed.
+     * Otherwise, the simulation has finished and no more measurements should be scheduled.
+     */
     private void scheduleMeasurement() {
-        /*
-        Just re-schedule measurements if there are other events to be processed.
-        Otherwise, the simulation has finished and no more measurements should be scheduled.
-        */
         if (getSimulation().isThereAnyFutureEvt(evt -> evt.getTag() != POWER_MEASUREMENT)) {
             schedule(this, measurementInterval, POWER_MEASUREMENT);
         }

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeter.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeter.java
@@ -79,6 +79,7 @@ public class PowerMeter extends CloudSimEntity {
         switch (evt.getTag()) {
             case POWER_MEASUREMENT:
                 measurePowerConsumption();
+                scheduleMeasurement();
                 break;
             case CloudSimTags.END_OF_SIMULATION:
                 this.shutdownEntity();
@@ -103,7 +104,16 @@ public class PowerMeter extends CloudSimEntity {
             .reduce(PowerMeasurement::add)
             .orElse(new PowerMeasurement());
         powerMeasurements.add(measurement);
-        schedule(this, measurementInterval, POWER_MEASUREMENT);
+    }
+
+    private void scheduleMeasurement() {
+        /*
+        Just re-schedule measurements if there are other events to be processed.
+        Otherwise, the simulation has finished and no more measurements should be scheduled.
+        */
+        if (getSimulation().isThereAnyFutureEvt(evt -> evt.getTag() != POWER_MEASUREMENT)) {
+            schedule(this, measurementInterval, POWER_MEASUREMENT);
+        }
     }
 
     @Override

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeter.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/power/PowerMeter.java
@@ -112,7 +112,7 @@ public class PowerMeter extends CloudSimEntity {
      */
     private void scheduleMeasurement() {
         if (getSimulation().isThereAnyFutureEvt(evt -> evt.getTag() != POWER_MEASUREMENT)) {
-            schedule(this, measurementInterval, POWER_MEASUREMENT);
+            schedule(measurementInterval, POWER_MEASUREMENT);
         }
     }
 


### PR DESCRIPTION
Only re-schedule power measurements if there are other events to be processed