### PR TITLE
Update some comments in some VmAllocationPolicies

### DIFF
--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyBestFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyBestFit.java
@@ -31,9 +31,9 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
- * A Worst Fit VmAllocationPolicy implementation that chooses, as
- * the host for a VM, that one with the most number of PEs in use,
- * which are enough for a VM.
+ * A Best Fit VmAllocationPolicy implementation that chooses, as
+ * the host for a VM, the one with the most number of PEs in use,
+ * which has enough free PEs for a VM.
  *
  * <p>This is a really computationally complex policy since the worst-case complexity
  * to allocate a Host for a VM is O(N), where N is the number of Hosts.

--- a/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyWorstFit.java
+++ b/cloudsim-plus/src/main/java/org/cloudbus/cloudsim/allocationpolicies/VmAllocationPolicyWorstFit.java
@@ -32,8 +32,8 @@ import java.util.stream.Stream;
 
 /**
  * A Worst Fit VmAllocationPolicy implementation that chooses, as
- * the host for a VM, that one with the least number of PEs in use,
- * which are enough for the VM.
+ * the host for a VM, the one with the least number of PEs in use,
+ * which has enough free PEs for the VM.
  *
  * <p>This is a really computationally complex policy since the worst-case complexity
  * to allocate a Host for a VM is O(N), where N is the number of Hosts.


### PR DESCRIPTION
The first sentence for VmAllocationPolicyBestFit is wrong. "Best Fit" is
used to replace "Worst Fit."

The latter parts of the first sentences are also revised for better
understanding.