### PR TITLE
Fix #542

### DIFF
--- a/src/main/java/org/cloudsimplus/vms/VmAbstract.java
+++ b/src/main/java/org/cloudsimplus/vms/VmAbstract.java
@@ -219,7 +219,6 @@ public non-sealed abstract class VmAbstract extends CustomerEntityAbstract imple
 
         setInMigration(false);
         this.host = Host.NULL;
-        setCloudletScheduler(new CloudletSchedulerTimeShared());
 
         this.setHorizontalScaling(HorizontalVmScaling.NULL);
         this.setRamVerticalScaling(VerticalVmScaling.NULL);

--- a/src/test/java/org/cloudsimplus/vms/VmSimpleTest.java
+++ b/src/test/java/org/cloudsimplus/vms/VmSimpleTest.java
@@ -18,6 +18,7 @@ import org.cloudsimplus.mocks.MocksHelper;
 import org.cloudsimplus.schedulers.MipsShare;
 import org.cloudsimplus.schedulers.cloudlet.CloudletScheduler;
 import org.cloudsimplus.schedulers.cloudlet.CloudletSchedulerAbstract;
+import org.cloudsimplus.schedulers.cloudlet.CloudletSchedulerSpaceShared;
 import org.cloudsimplus.schedulers.cloudlet.CloudletSchedulerTimeShared;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -347,5 +348,17 @@ public class VmSimpleTest {
         vm.setCreated(true);
 
         assertTrue(vm.getCurrentRequestedMips().isEmpty());
+    }
+
+    /**
+     * Checks that a CloudletScheduler passed in the constructor is preserved
+     * and not overwritten during VM initialization.
+     * @see <a href="https://github.com/cloudsimplus/cloudsimplus/issues/542">Issue #542</a>
+     */
+    @Test
+    public void cloudletSchedulerPassedInConstructorIsPreserved() {
+        final var scheduler = new CloudletSchedulerSpaceShared();
+        final var vm = new VmSimple(1000, 2, scheduler);
+        assertInstanceOf(CloudletSchedulerSpaceShared.class, vm.getCloudletScheduler());
     }
 }


### PR DESCRIPTION
This pull request makes a small change to the VM initialization logic by removing the default assignment of a `CloudletSchedulerTimeShared` scheduler in the `mutableAttributesInit` method. 

Closes #542.
