### PR TITLE
Fixes #544

### DIFF
--- a/src/main/java/org/cloudsimplus/brokers/DatacenterBrokerAbstract.java
+++ b/src/main/java/org/cloudsimplus/brokers/DatacenterBrokerAbstract.java
@@ -903,6 +903,7 @@ public non-sealed abstract class DatacenterBrokerAbstract extends CloudSimEntity
             getSimulation().clockStr(), getName(), cloudlet, lifeTime, cloudlet.getVm());
 
         if (cloudlet.getVm().getCloudletScheduler().isEmpty()) {
+            ((VmAbstract) cloudlet.getVm()).freeAllPes();
             requestIdleVmDestruction(cloudlet.getVm());
             return true;
         }

--- a/src/main/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerAbstract.java
+++ b/src/main/java/org/cloudsimplus/schedulers/cloudlet/CloudletSchedulerAbstract.java
@@ -524,6 +524,12 @@ public abstract non-sealed class CloudletSchedulerAbstract implements CloudletSc
             usedPes += cle.getCloudlet().getPesNumber();
         }
 
+        /*
+        TODO: This logic should be encapsuled inside the VmAbstract class.
+        A new method should be introduced that accepts just the usedPes and
+        updates the freePesNumber accordingly, since that is a property of the VM and not of the scheduler.
+        This will make this call much simples and provides more cohesion.
+        */
         ((VmSimple) vm).setFreePesNumber(vm.getPesNumber() - usedPes);
 
         return nextProcessing;

--- a/src/main/java/org/cloudsimplus/vms/VmAbstract.java
+++ b/src/main/java/org/cloudsimplus/vms/VmAbstract.java
@@ -305,6 +305,13 @@ public non-sealed abstract class VmAbstract extends CustomerEntityAbstract imple
     }
 
     /**
+     * Frees all PEs of this VM, setting the {@link #freePesNumber} to the total number of PEs.
+     */
+    public void freeAllPes() {
+        setFreePesNumber(getPesNumber());
+    }
+
+    /**
      * Adds a given number of expected free PEs to the total number of expected free PEs.
      * This value is updated as cloudlets are assigned to VMs but not submitted to the broker for running yet.
      *

--- a/src/main/java/org/cloudsimplus/vms/VmAbstract.java
+++ b/src/main/java/org/cloudsimplus/vms/VmAbstract.java
@@ -128,6 +128,7 @@ public non-sealed abstract class VmAbstract extends CustomerEntityAbstract imple
         this.bootModel = BootModel.NULL;
 
         // Initializes the number of free PEs as the number of VM PEs
+        // TODO: It's not calling setFreePesNumber, which has some logic there.
         this.freePesNumber = pesNumber;
         this.expectedFreePesNumber = pesNumber;
 
@@ -300,6 +301,8 @@ public non-sealed abstract class VmAbstract extends CustomerEntityAbstract imple
         if (freePesNumber < 0) {
             freePesNumber = 0;
         }
+
+        // TODO: If the freePesNumber is changed, a warning should be issued
         this.freePesNumber = Math.min(freePesNumber, getPesNumber());
         return this;
     }

--- a/src/test/java/org/cloudsimplus/integrationtests/VmFreePesAfterCloudletsFinishTest.java
+++ b/src/test/java/org/cloudsimplus/integrationtests/VmFreePesAfterCloudletsFinishTest.java
@@ -1,0 +1,70 @@
+package org.cloudsimplus.integrationtests;
+
+import org.cloudsimplus.brokers.DatacenterBrokerSimple;
+import org.cloudsimplus.cloudlets.CloudletSimple;
+import org.cloudsimplus.core.CloudSimPlus;
+import org.cloudsimplus.datacenters.DatacenterSimple;
+import org.cloudsimplus.hosts.HostSimple;
+import org.cloudsimplus.resources.PeSimple;
+import org.cloudsimplus.vms.VmSimple;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Verifies that after all Cloudlets finish execution on a VM,
+ * both {@code freePesNumber} and {@code expectedFreePesNumber}
+ * are correctly updated to the total number of VM PEs.
+ *
+ * @author Theodoros Aslanidis
+ * @see <a href="https://github.com/cloudsimplus/cloudsimplus/issues/544">Issue #544</a>
+ */
+public final class VmFreePesAfterCloudletsFinishTest {
+    private static final int HOST_MIPS = 1000;
+    private static final int VM_PES = 2;
+    private static final int CLOUDLET_PES = 1;
+    private static final int CLOUDLET_LENGTH = 10_000;
+    private static final int HRAM = 2048;
+    private static final int HBW = 10_000;
+    private static final int HSTORAGE = 1_000_000;
+    private static final int VM_RAM = 512;
+    private static final int VM_BW = 1000;
+
+    private CloudSimPlus simulation;
+    private VmSimple vm;
+
+    @BeforeEach
+    public void setUp() {
+        simulation = new CloudSimPlus();
+        final var host = new HostSimple(HRAM, HBW, HSTORAGE, List.of(newPe(), newPe()));
+        new DatacenterSimple(simulation, List.of(host));
+
+        final var broker = new DatacenterBrokerSimple(simulation);
+        vm = new VmSimple(HOST_MIPS, VM_PES);
+        vm.setRam(VM_RAM).setBw(VM_BW).setSize(HBW);
+        broker.submitVmList(List.of(vm));
+        final var cloudlet = new CloudletSimple(CLOUDLET_LENGTH, CLOUDLET_PES);
+        broker.submitCloudletList(List.of(cloudlet));
+    }
+
+    private static @NotNull PeSimple newPe() {
+        return new PeSimple(HOST_MIPS);
+    }
+
+    /**
+     * After all Cloudlets finish, both freePesNumber and expectedFreePesNumber
+     * must be equal to the total VM PEs.
+     */
+    @Test
+    public void freePesEqualsVmPesAfterAllCloudletsFinish() {
+        simulation.start();
+        assertEquals(VM_PES, vm.getFreePesNumber(),
+            "freePesNumber should equal total VM PEs after all Cloudlets finish");
+        assertEquals(VM_PES, vm.getExpectedFreePesNumber(),
+            "expectedFreePesNumber should equal total VM PEs after all Cloudlets finish");
+    }
+}


### PR DESCRIPTION
Fix freePes not updated when all Cloudlets finish

When all Cloudlets finish, freePes wasn't being reset. Added a call to `setFreePesNumber(vm.getPesNumber())` when scheduler becomes empty.

Fixes #544 