### PR TITLE
Fixes #546: expectedFreePes overflow when cloudlet requires more PEs than available

### DIFF
--- a/src/main/java/org/cloudsimplus/vms/VmAbstract.java
+++ b/src/main/java/org/cloudsimplus/vms/VmAbstract.java
@@ -339,7 +339,7 @@ public non-sealed abstract class VmAbstract extends CustomerEntityAbstract imple
      * @param expectedFreePes the expected free PEs number to set
      */
     private Vm setExpectedFreePesNumber(final long expectedFreePes) {
-        this.expectedFreePesNumber = Math.max(expectedFreePes, 0);
+        this.expectedFreePesNumber = Math.max(Math.min(expectedFreePes, getPesNumber()), 0);
         return this;
     }
 

--- a/src/main/java/org/cloudsimplus/vms/VmAbstract.java
+++ b/src/main/java/org/cloudsimplus/vms/VmAbstract.java
@@ -339,7 +339,7 @@ public non-sealed abstract class VmAbstract extends CustomerEntityAbstract imple
      * @param expectedFreePes the expected free PEs number to set
      */
     private Vm setExpectedFreePesNumber(final long expectedFreePes) {
-        this.expectedFreePesNumber = Math.max(Math.min(expectedFreePes, getPesNumber()), 0);
+        this.expectedFreePesNumber = Math.clamp(expectedFreePes, 0, getPesNumber());
         return this;
     }
 

--- a/src/test/java/org/cloudsimplus/integrationtests/VmExpectedFreePesOverflowTest.java
+++ b/src/test/java/org/cloudsimplus/integrationtests/VmExpectedFreePesOverflowTest.java
@@ -1,0 +1,89 @@
+package org.cloudsimplus.integrationtests;
+
+import org.cloudsimplus.brokers.DatacenterBrokerSimple;
+import org.cloudsimplus.cloudlets.CloudletSimple;
+import org.cloudsimplus.core.CloudSimPlus;
+import org.cloudsimplus.datacenters.DatacenterSimple;
+import org.cloudsimplus.hosts.HostSimple;
+import org.cloudsimplus.resources.Pe;
+import org.cloudsimplus.resources.PeSimple;
+import org.cloudsimplus.vms.VmSimple;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies that {@code expectedFreePesNumber} does not overflow
+ * beyond the total VM PEs when a Cloudlet requires more PEs
+ * than the VM has available.
+ *
+ * @author Theodoros Aslanidis
+ * @see <a href="https://github.com/cloudsimplus/cloudsimplus/issues/546">Issue #546</a>
+ */
+public final class VmExpectedFreePesOverflowTest {
+    // Constants that matter to the test.
+    private static final int VM_PES = 2;
+    private static final int CLOUDLET_PES_HIGHER_THAN_VM_CAPACITY = 3;
+
+    // Attributes used across the entire test class
+    private static final int HOST_MIPS = 1000;
+    private CloudSimPlus simulation;
+    private VmSimple vm;
+
+    @BeforeEach
+    public void setUp() {
+        // Values for attributes that don't matter to the test
+        final int cloudletLen = 10_000;
+        final int hRAM = 2048;
+        final int hBW = 10_000;
+        final int hStorage = 1_000_000;
+        final int vmRAM = 512;
+        final int vmBW = 1000;
+        final int vmStorage = 10_000;
+
+        simulation = new CloudSimPlus();
+        final List<Pe> peList = List.of(newPe(), newPe(), newPe(), newPe());
+        final var host = new HostSimple(hRAM, hBW, hStorage, peList);
+        new DatacenterSimple(simulation, List.of(host));
+
+        final var broker = new DatacenterBrokerSimple(simulation);
+        vm = new VmSimple(HOST_MIPS, VM_PES);
+        vm.setRam(vmRAM).setBw(vmBW).setSize(vmStorage);
+        broker.submitVmList(List.of(vm));
+
+        final var cloudlet = new CloudletSimple(cloudletLen, CLOUDLET_PES_HIGHER_THAN_VM_CAPACITY);
+        broker.submitCloudletList(List.of(cloudlet));
+    }
+
+    private static @NotNull PeSimple newPe() {
+        return new PeSimple(HOST_MIPS);
+    }
+
+    /**
+     * When a Cloudlet requires more PEs than the VM has,
+     * {@code expectedFreePesNumber} must never exceed the total VM PEs
+     * after the Cloudlet finishes.
+     */
+    @Test
+    public void expectedFreePesDoesNotExceedVmPesAfterCloudletFinish() {
+        assumeTrue(CLOUDLET_PES_HIGHER_THAN_VM_CAPACITY > VM_PES,
+            "This test is only valid if the Cloudlet requires more PEs than the VM has");
+
+        simulation.start();
+        assertTrue(vm.getExpectedFreePesNumber() <= vm.getPesNumber(),
+            "expectedFreePesNumber (%d) should not exceed total VM PEs (%d)"
+                .formatted(vm.getExpectedFreePesNumber(), vm.getPesNumber()));
+
+        assertEquals(VM_PES, vm.getExpectedFreePesNumber(),
+            "expectedFreePesNumber should equal total VM PEs after all Cloudlets finish");
+
+        assertEquals(VM_PES, vm.getFreePesNumber(),
+            "freePesNumber should equal total VM PEs after all Cloudlets finish");
+    }
+}


### PR DESCRIPTION

**Bug:** When a cloudlet requires more PEs than the VM has, `removeExpectedFreePesNumber` clamps to 0, but `addExpectedFreePesNumber` adds back the full cloudlet PEs on completion, causing `expectedFreePes` to exceed `totalPES`.

**See #546 for more information on this bug**

**Fix:** Added upper bound clamp in `VmAbstract.setExpectedFreePesNumber()`:

```java
this.expectedFreePesNumber = Math.max(Math.min(expectedFreePes, getPesNumber()), 0);
```